### PR TITLE
Fix typeError when no contact is available.

### DIFF
--- a/js/public/script.js
+++ b/js/public/script.js
@@ -999,7 +999,7 @@ app.service('ContactService', [ 'DavClient', 'AddressBookService', 'Contact', '$
 				return element.categories();
 			}).reduce(function(a, b){
 				return a.concat(b);
-			}).sort(), true);
+			}, []).sort(), true);
 			return [t('contacts', 'All contacts')].concat(groups);
 		});
 	};

--- a/js/services/contact_service.js
+++ b/js/services/contact_service.js
@@ -58,7 +58,7 @@ app.service('ContactService', [ 'DavClient', 'AddressBookService', 'Contact', '$
 				return element.categories();
 			}).reduce(function(a, b){
 				return a.concat(b);
-			}).sort(), true);
+			}, []).sort(), true);
 			return [t('contacts', 'All contacts')].concat(groups);
 		});
 	};


### PR DESCRIPTION
`Uncaught (in promise) TypeError: Reduce of empty array with no initial value(…)`

To reproduce: Start contacts app without any contact available.

This PR adds an initial value for the reduce function to overcome this error.
