### PR TITLE
Add elipses to name, org, title in contact details header

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -20,6 +20,9 @@
 	color: #fff !important;
 	background: transparent !important;
 	border: none !important;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
 }
 .contactdetails__header .contactdetails__org {
 	position: absolute;
@@ -29,7 +32,7 @@
 .contactdetails__header .contactdetails__title {
 	position: absolute;
 	left: 201px;
-	width: 100px !important;
+	width: 125px !important;
 }
 /* fix placeholder color */
 .contactdetails__header .contactdetails__name::-webkit-input-placeholder,


### PR DESCRIPTION
Make things look a little nicer in the header with long companies, titles, names etc:

Before:
![screen shot 2016-03-10 at 15 11 35](https://cloud.githubusercontent.com/assets/660805/13673749/67cee9c6-e6d2-11e5-912f-76bd00041934.png)

After:
![screen shot 2016-03-10 at 15 08 52](https://cloud.githubusercontent.com/assets/660805/13673734/5bac34d2-e6d2-11e5-87c4-3b54201cb14a.png)

You can still click in the fields and edit the full value and the full value is stored.

@jancborchardt  @Henni 
