### PR TITLE
Should fix #174.

### DIFF
--- a/js/services/dav_service.js
+++ b/js/services/dav_service.js
@@ -1,6 +1,6 @@
 app.service('DavService', function(DavClient) {
 	return DavClient.createAccount({
-		server: OC.linkToRemoteBase('dav/addressbooks'),
+		server: OC.linkToRemote('dav/addressbooks'),
 		accountType: 'carddav',
 		useProvidedPath: true
 	});


### PR DESCRIPTION
> OC.linkToRemote('dav/addressbooks')
> "http://localhost/oc/remote.php/dav/addressbooks"
> 
> OC.linkToRemoteBase('dav/addressbooks')
> "/oc/remote.php/dav/addressbooks"

The dav lib sometimes did correctly add the host, that's why it was not reproducible for everyone.

cc @nicokaiser @tsumi @z000ao8q @Henni 
