### PR TITLE
First contact load fix, direct access to contact, contact not in group, group load and order - fix #312

### DIFF
--- a/js/filters/contactGroup_filter.js
+++ b/js/filters/contactGroup_filter.js
@@ -22,6 +22,6 @@ angular.module('contactsApp')
 				}
 			}
 		}
-		return filter;
+		return filter.length === 0 ? contacts : filter;
 	};
 });


### PR DESCRIPTION
Fix multiple issues:
- When loading the page directly on a specific group, the first contact loaded was taken from the main contact list which often results by displaying a contact not in the requested group
- When reclicking the already selected group from the list after a fresh page load resulted by the contact details disappearing
- The contacts starting with a special character was being ignored when choosing the first contact to load
- When a uid is specified, the script will  now be looking for it in the specified group, if not found, the first contact of group will be displayed
