### PR TITLE
Auto-resizing input for org and title layout + header improvements

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -12,27 +12,31 @@
 	top: 15px;
 	left: 100px;
 }
+.contactdetails__header #details-org-container {
+	position: absolute;
+	display: flex;
+	top: 50px;
+	left: 100px;
+	width: 70%;
+}
 .contactdetails__header .contactdetails__name,
 .contactdetails__header .contactdetails__org,
 .contactdetails__header .contactdetails__title {
 	font-size: inherit !important;
-	width: 100% !important;
+	width: auto !important;
 	color: #fff !important;
 	background: transparent !important;
 	border: none !important;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
+	max-width: 100%;
+	min-width: 25%;
+	margin: 3px 0;
 }
-.contactdetails__header .contactdetails__org {
-	position: absolute;
-	left: 101px;
-	width: 100px !important;
-}
+.contactdetails__header .contactdetails__org,
 .contactdetails__header .contactdetails__title {
-	position: absolute;
-	left: 201px;
-	width: 125px !important;
+	max-width: 50%;
 }
 /* fix placeholder color */
 .contactdetails__header .contactdetails__name::-webkit-input-placeholder,

--- a/js/components/inputresize_directive.js
+++ b/js/components/inputresize_directive.js
@@ -1,0 +1,15 @@
+angular.module('contactsApp')
+.directive('inputresize', function() {
+	return {
+		restrict: 'A',
+		link : function (scope, element) {
+			var elInput = element.val();
+			element.bind('keydown keyup load focus', function() {
+				elInput = element.val();
+				// If set to 0, the min-width css data is ignored
+				var length = elInput.length > 1 ? elInput.length : 1;
+				element.attr('size', length);
+			});
+		}
+	};
+});

--- a/templates/contactDetails.html
+++ b/templates/contactDetails.html
@@ -11,13 +11,16 @@
 			<img ng-if="ctrl.photo!==undefined" class="contactdetails__logo avatar" data-ng-src="data:image/png;base64,{{ctrl.photo}}" />
 			<h2>
 				<input type="text" id="details-fullName" class="contactdetails__name" placeholder="{{ctrl.t.placeholderName}}" autocomplete="off"
-				name="email" ng-model="ctrl.contact.fullName" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value="" />
+					   name="email" ng-model="ctrl.contact.fullName" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value=""
+					   inputresize size="{{ctrl.contact.fullName().length > 1 ? ctrl.contact.fullName().length : '1'}}" />
 			</h2>
-			<div>
+			<div id="details-org-container">
 				<input type="text" id="details-org" class="contactdetails__org" placeholder="{{ctrl.t.placeholderOrg}}" autocomplete="off"
-					   name="email" ng-model="ctrl.contact.org" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value="" />
+					   name="email" ng-model="ctrl.contact.org" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value=""
+					   inputresize size="{{ctrl.contact.org().length > 1 ? ctrl.contact.org().length : '1'}}" />
 				<input type="text" id="details-title" class="contactdetails__title" placeholder="{{ctrl.t.placeholderTitle}}" autocomplete="off"
-					   name="email" ng-model="ctrl.contact.title" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value="" />
+					   name="email" ng-model="ctrl.contact.title" ng-model-options="{ getterSetter: true, debounce: 500 }" ng-change="ctrl.updateContact()" value=""
+					   inputresize size="{{ctrl.contact.title().length > 1 ? ctrl.contact.title().length : '1'}}" />
 			</div>
 			<button ng-click="ctrl.deleteContact()" class="icon-delete-white" title="Delete"></button>
 		</header>


### PR DESCRIPTION
REPLACE #314
- Set the fullName h2 and org+title div at 70% for better rendering
- Added a script to auto-resize the org & title inputs
- Added a max and min width on those inputs (20% & 50%) because they still are on the same line

This should allow for a clean display and something pretty good to see.
Mobile is good too, but of course the ellipsis are visible because of the low width-res.

Closes #293 and refs #286 
