### PR TITLE
Hide the Add Contact button if we've got an invalid contact

### DIFF
--- a/css/public/style.css
+++ b/css/public/style.css
@@ -318,7 +318,10 @@ li.addressBook-share-item span.shareeIdentifier {
 
 
 
-
+/* Contacts List */
+#new-contact-button {
+	margin: 14px auto; /* to have the same height than a contact*/
+}
 
 
 

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -7,6 +7,7 @@ angular.module('contactsApp')
 	ctrl.contactList = [];
 	ctrl.searchTerm = '';
 	ctrl.show = true;
+	ctrl.invalid = false;
 
 	ctrl.t = {
 		addContact : t('contacts', 'Add contact'),
@@ -146,6 +147,15 @@ angular.module('contactsApp')
 				}
 				unbindWatch(); // unbind as we only want one update
 			});
+		}
+	});
+
+	// Watch if we have an invalid contact
+	$scope.$watch('ctrl.contactList[0].fullName()', function(fullName) {
+		if(fullName === '') {
+			ctrl.invalid = true;
+		} else {
+			ctrl.invalid = false;
 		}
 	});
 

--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -152,11 +152,7 @@ angular.module('contactsApp')
 
 	// Watch if we have an invalid contact
 	$scope.$watch('ctrl.contactList[0].fullName()', function(fullName) {
-		if(fullName === '') {
-			ctrl.invalid = true;
-		} else {
-			ctrl.invalid = false;
-		}
+		ctrl.invalid = fullName === '';
 	});
 
 	ctrl.createContact = function() {

--- a/js/filters/newContact_filter.js
+++ b/js/filters/newContact_filter.js
@@ -1,0 +1,6 @@
+angular.module('contactsApp')
+.filter('newContact', function() {
+	return function(input) {
+		return input !== '' ? input : t('contacts', 'New contact');
+	};
+});

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -2,6 +2,6 @@
     <img class="app-content-list-item-icon contact__icon" ng-show="ctrl.contact.photo()!==undefined" data-ng-src="data:image/png;base64,{{ctrl.contact.photo()}}" />
     <div class="app-content-list-item-icon contact__icon" ng-show="ctrl.contact.photo()===undefined" ng-style="{'background-color': (ctrl.contact.uid() | contactColor) }">{{ ctrl.contact.fullName() | firstCharacter }}</div>
     <div class="app-content-list-item-star icon-star" data-starred="false"></div>
-    <div class="app-content-list-item-line-one" ng-class="{'no-line-two':!ctrl.contact.email()}">{{ctrl.contact.fullName()}}</div>
+    <div class="app-content-list-item-line-one" ng-class="{'no-line-two':!ctrl.contact.email()}">{{ ctrl.contact.fullName() | newContact }}</div>
     <div class="app-content-list-item-line-two">{{ctrl.contact.email()}}</div>
 </a>

--- a/templates/contactList.html
+++ b/templates/contactList.html
@@ -1,10 +1,11 @@
 <div style="height: 90%" class="contacts-list" ng-class="{loading: ctrl.loading, 'mobile-show': ctrl.show}">
-        <button ng-show="!ctrl.loading" class="app-content-list-button" type="button" name="button" ng-click="ctrl.createContact()">{{ctrl.t.addContact}}</button>
+        <button ng-show="!ctrl.loading && !ctrl.invalid" class="app-content-list-button" id="new-contact-button"
+				type="button" name="button" ng-click="ctrl.createContact()">{{ctrl.t.addContact}}</button>
         <div class="app-content-list-item"
-	     ng-repeat="contact in ctrl.contactList = (ctrl.contacts | contactGroupFilter:ctrl.routeParams.gid | orderBy:'fullName()' | filter:query) track by contact.uid()"
-	     contact data="contact"
-	     ng-click="setSelected(contact.uid())"
-	     ng-class="{active: contact.uid() === ctrl.getSelectedId()}">
+			 ng-repeat="contact in ctrl.contactList = (ctrl.contacts | contactGroupFilter:ctrl.routeParams.gid | orderBy:'fullName()' | filter:query) track by contact.uid()"
+			 contact data="contact"
+			 ng-click="setSelected(contact.uid())"
+			 ng-class="{active: contact.uid() === ctrl.getSelectedId()}">
 	</div>
 	<div ng-show="!ctrl.contactList.length && !ctrl.loading && ctrl.searchTerm !== ''">
 	        <div id="emptycontent" class="emptycontent-search">


### PR DESCRIPTION
This prevent from adding multiple empty contacts as long as you don't have filled the full name field (aka FN).
- Hides the new contact button when we have an invalid contact
- Resized the button height to match a contactList item height.
- A new contact now take the place of the button.

This fixes #160
![screencast](https://cloud.githubusercontent.com/assets/14975046/14342221/68b76756-fc98-11e5-981f-1f869e50ebd2.gif)
