### PR TITLE
Fix error loading page when no contacts

### DIFF
--- a/js/components/contactList/contactList_controller.js
+++ b/js/components/contactList/contactList_controller.js
@@ -69,9 +69,13 @@ angular.module('contactsApp')
 
 	// Get contacts
 	ContactService.getAll().then(function(contacts) {
-		$scope.$apply(function() {
-			ctrl.contacts = contacts;
-		});
+		if(contacts.length>0) {
+			$scope.$apply(function() {
+				ctrl.contacts = contacts;
+			});
+		} else {
+			ctrl.loading = false;
+		}
 	});
 
 	// Wait for ctrl.contactList to be updated, load the first contact and kill the watch


### PR DESCRIPTION
Did a mistake with the new loading fix (ref #323)
When you don't have any contacts, loading the page generate an error and doesn't load further.
