### PR TITLE
Remove testing against stable9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,8 @@ matrix:
           env: DB=mysql
         - php: 7.2
           env: DB=mysql
-        - php: 5.4
-          env:  DB=pgsql CORE_BRANCH=stable9
-        - php: 5.6
-          env:  DB=pgsql CORE_BRANCH=stable9.1
         - php: 7.2
-          env:  DB=pgsql CORE_BRANCH=master
+          env: DB=pgsql CORE_BRANCH=master
     fast_finish: true
 
 before_install:


### PR DESCRIPTION
Unless someone knows a reason why we need to run this against PHP  5.4 stable9 and PHP 5.6 stable9.1