### PR TITLE
Remove old test-syntax-php

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -171,6 +171,9 @@ matrix:
     - PHP_VERSION: 7.2
       TEST_SUITE: owncloud-coding-standard
 
+    - PHP_VERSION: 7.1
+      TEST_SUITE: owncloud-coding-standard
+
     - PHP_VERSION: 5.6
       TEST_SUITE: owncloud-coding-standard
 

--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
 	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
 
 .PHONY: test-codecheck
-test-codecheck: test-syntax-php
+test-codecheck:
 	$(occ) app:check-code $(app_name) -c private -c strong-comparison
 
 .PHONY: test-codecheck-deprecations


### PR DESCRIPTION
because PHP "lint" is done effectively by owncloud-coding-standard these days. (note: this `Makefile` had a dependency on `test-syntax-php` but no actual `test-syntax-php` target, so that was an error anyway)

Added owncloud-coding-standard for PHP 7.1 so that we cover the supported PHP versions.