### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,6 +25,6 @@ In addition to managing synchronized contacts the application also offers a feat
     <repository type="git">https://github.com/owncloud/contacts.git</repository>
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/760f2783b03fd26cbc920188b672f5f5efe548c0/contacts/contacts.png</screenshot>
     <dependencies>
-        <owncloud min-version="9.0" max-version="10" />
+        <owncloud min-version="10.2" max-version="10" />
     </dependencies>
 </info>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/contacts",
   "config" : {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c72c3333e74a53616bd5a9f6fe4636d",
+    "content-hash": "a25acadddf1cfd967e5596de102b52cc",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
