### PR TITLE
Rename share icon to be adblock friendly

### DIFF
--- a/templates/addressBook.html
+++ b/templates/addressBook.html
@@ -3,7 +3,7 @@
 
     <span class="action">
         <span
-            class="addressbooklist-icon icon-share"
+            class="addressbooklist-icon icon-shared"
             title="{{ctrl.t.shareAddressbook}}"
             ng-click="ctrl.toggleSharesEditor(ctrl.addressBook)">
         </span>


### PR DESCRIPTION
Similar by https://github.com/owncloud/core/pull/35147 / https://github.com/owncloud/core/pull/35199

See https://github.com/owncloud/core/issues/35070 / https://github.com/owncloud/core/issues/33642 / https://github.com/owncloud/core/issues/33579 also