### PR TITLE
[tests-only] [full-ci] Change appInstallCommand to work with PHP unit tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,6 @@ dir = {
 }
 
 config = {
-    "app": "contacts",
     "rocketchat": {
         "channel": "builds",
         "from_secret": "private_rocketchat",
@@ -1662,7 +1661,7 @@ def installAppPhp(ctx, phpVersion):
 def installAppJavaScript(ctx):
     nothingToDo = True
     commandArray = [
-        "cd %s/apps/%s" % (dir["server"], config["app"]),
+        "cd %s/apps/%s" % (dir["server"], ctx.repo.name),
     ]
 
     if "appInstallCommandJavaScript" in config:
@@ -1680,7 +1679,7 @@ def installAppJavaScript(ctx):
 
     return [
         {
-            "name": "install-app-js-%s" % config["app"],
+            "name": "install-app-js-%s" % ctx.repo.name,
             "image": "owncloudci/nodejs:%s" % getNodeJsVersion(),
             "pull": "always",
             "commands": commandArray,

--- a/.drone.star
+++ b/.drone.star
@@ -14,7 +14,8 @@ config = {
     "branches": [
         "master",
     ],
-    "appInstallCommand": "make npm",
+    "appInstallCommandPhp": "make composer",
+    "appInstallCommandJavaScript": "make npm",
     "codestyle": True,
     "phpstan": True,
     "phan": True,
@@ -354,7 +355,7 @@ def phpstan(ctx):
                     "path": "server/apps/%s" % ctx.repo.name,
                 },
                 "steps": installCore(ctx, "daily-master-qa", "sqlite", False) +
-                         installApp(ctx, phpVersion) +
+                         installAppPhp(ctx, phpVersion) +
                          installExtraApps(phpVersion, params["extraApps"]) +
                          setupServerAndApp(ctx, phpVersion, params["logLevel"], False, params["enableApp"]) +
                          [
@@ -599,7 +600,7 @@ def javascript(ctx, withCoverage):
             "path": "server/apps/%s" % ctx.repo.name,
         },
         "steps": installCore(ctx, "daily-master-qa", "sqlite", False) +
-                 installApp(ctx, "7.4") +
+                 installAppJavaScript(ctx) +
                  setupServerAndApp(ctx, "7.4", params["logLevel"], False, params["enableApp"]) +
                  params["extraSetup"] +
                  [
@@ -771,7 +772,7 @@ def phpTests(ctx, testType, withCoverage):
                         "path": "server/apps/%s" % ctx.repo.name,
                     },
                     "steps": installCore(ctx, "daily-master-qa", db, False) +
-                             installApp(ctx, phpVersion) +
+                             installAppPhp(ctx, phpVersion) +
                              installExtraApps(phpVersion, params["extraApps"]) +
                              setupServerAndApp(ctx, phpVersion, params["logLevel"], False, params["enableApp"]) +
                              setupCeph(params["cephS3"]) +
@@ -1102,7 +1103,8 @@ def acceptance(ctx):
                     "steps": installCore(ctx, testConfig["server"], testConfig["database"], testConfig["useBundledApp"]) +
                              installTestrunner(ctx, "7.4", testConfig["useBundledApp"]) +
                              (installFederated(testConfig["server"], testConfig["phpVersion"], testConfig["logLevel"], testConfig["database"], federationDbSuffix) + owncloudLog("federated") if testConfig["federatedServerNeeded"] else []) +
-                             installApp(ctx, testConfig["phpVersion"]) +
+                             installAppPhp(ctx, testConfig["phpVersion"]) +
+                             installAppJavaScript(ctx) +
                              installExtraApps(testConfig["phpVersion"], testConfig["extraApps"]) +
                              setupServerAndApp(ctx, testConfig["phpVersion"], testConfig["logLevel"], testConfig["federatedServerNeeded"], params["enableApp"]) +
                              owncloudLog("server") +
@@ -1637,35 +1639,53 @@ def installExtraApps(phpVersion, extraApps):
         "commands": commandArray,
     }]
 
-def installApp(ctx, phpVersion):
-    if "appInstallCommand" not in config:
+def installAppPhp(ctx, phpVersion):
+    if "appInstallCommandPhp" not in config:
         return []
 
-    if "buildJsDeps" not in config:
-        installJsDeps = False
-    else:
-        installJsDeps = config["buildJsDeps"]
+    # config["appInstallCommandPhp"] must be the command that is needed to
+    # install just the PHP-related part of the app. The docker image has PHP
+    # and "base" tools. But it does not have JavaScript tools like nodejs,
+    # npm, yarn etc.
+    return [
+        {
+            "name": "install-app-php-%s" % ctx.repo.name,
+            "image": "owncloudci/php:%s" % phpVersion,
+            "pull": "always",
+            "commands": [
+                "cd %s/apps/%s" % (dir["server"], ctx.repo.name),
+                config["appInstallCommandPhp"],
+            ],
+        },
+    ]
+
+def installAppJavaScript(ctx):
+    nothingToDo = True
+    commandArray = [
+        "cd %s/apps/%s" % (dir["server"], config["app"]),
+    ]
+
+    if "appInstallCommandJavaScript" in config:
+        nothingToDo = False
+        commandArray.append(config["appInstallCommandJavaScript"])
+
+    if "buildJsDeps" in config:
+        if config["buildJsDeps"]:
+            nothingToDo = False
+            commandArray.append("make install-js-deps")
+            commandArray.append("make build-dev")
+
+    if (nothingToDo):
+        return []
 
     return [
         {
             "name": "install-app-js-%s" % config["app"],
             "image": "owncloudci/nodejs:%s" % getNodeJsVersion(),
             "pull": "always",
-            "commands": [
-                "cd /var/www/owncloud/server/apps/%s" % config["app"],
-                "make install-js-deps",
-                "make build-dev",
-            ],
+            "commands": commandArray,
         },
-    ] if installJsDeps else [] + [{
-        "name": "install-app-%s" % ctx.repo.name,
-        "image": "owncloudci/php:%s" % phpVersion,
-        "pull": "always",
-        "commands": [
-            "cd %s/apps/%s" % (dir["server"], ctx.repo.name),
-            config["appInstallCommand"],
-        ],
-    }]
+    ]
 
 def setupServerAndApp(ctx, phpVersion, logLevel, federatedServerNeeded = False, enableApp = True):
     return [{

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules/
 
 # SonarCloud scanner
 .scannerwork
+
+# drone CI is in .drone.star, do not let someone accidentally commit a local .drone.yml
+.drone.yml


### PR DESCRIPTION
https://drone.owncloud.com/owncloud/contacts/977/3/3
```
7.3: Pulling from owncloudci/php
Digest: sha256:5c090434ce667b422b4258f9a24eeed2b390a8ca47f64b29b18917b492d061a2
Status: Image is up to date for owncloudci/php:7.3
+ cd /var/www/owncloud/server/apps/contacts
+ make npm
npm run build
Makefile:120: recipe for target 'npm' failed
make: npm: Command not found
make: *** [npm] Error 127
```

The app has both PHP and JavaScript dependencies. To install the PHP dependencies, the `owncloudci/php` image is needed. To install the JavaScript dependencies, the `owncloudci/nodejs` image is needed.

I  have modified the drone starlark so that both "appInstallCommandPhp" and/or  "appInstallCommandJavaScript" can be specified in the `config` section as needed. Each will be executed in the appropriate `php` or `nodejs` docker image, if specified.

This should work flexibly for other oC10 apps. I have copied the code back to https://github.com/owncloud/activity/pull/1007 so that that gets implement when we next update the oC10 app starlark across the apps.