### PR TITLE
[tests-only] [full-ci] Run phan with PHP 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -49,7 +49,14 @@ config = {
     "appInstallCommandJavaScript": "make npm",
     "codestyle": True,
     "phpstan": True,
-    "phan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "javascript": {
         "coverage": True,
         "extraServices": [


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.