### PR TITLE
feat: add translation sync workflow

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 2 * * 1'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   sync:
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -2,7 +2,7 @@ name: Translation Sync
 
 on:
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@add-translation-sync
     with:
       mode: old
     secrets:

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -2,7 +2,7 @@ name: Translation Sync
 
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -17,3 +17,5 @@ jobs:
       sub_path: l10n
     secrets:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -14,5 +14,6 @@ jobs:
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@add-translation-sync
     with:
       mode: old
+      sub_path: l10n
     secrets:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -17,5 +17,5 @@ jobs:
       sub_path: l10n
     secrets:
       TX_TOKEN: ${{ secrets.TX_TOKEN }}
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
+      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   sync:
-    permissions:
-      contents: write
-      pull-requests: write
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
     with:
       mode: old

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * 1'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   sync:

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -1,0 +1,14 @@
+name: Translation Sync
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
+    with:
+      mode: old
+    secrets:
+      TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   sync:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
     with:
       mode: old

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -4,14 +4,13 @@ on:
   schedule:
     - cron: '0 2 * * 1'
   workflow_dispatch:
-  pull_request:
 
 jobs:
   sync:
     permissions:
       contents: write
       pull-requests: write
-    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@add-translation-sync
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
     with:
       mode: old
       sub_path: l10n


### PR DESCRIPTION
## Summary

Adds a nightly translation sync workflow that calls the reusable workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) (owncloud/reusable-workflows#24).

Push is authenticated via the repo's own `GITHUB_TOKEN` — no PAT or SSH key needed.

`TX_TOKEN` must be available as a repository or organisation secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)