### PR TITLE
fix(deps): migrate vendored dav lib from xmldom to @xmldom/xmldom

### DIFF
--- a/js/dav/dav.js
+++ b/js/dav/dav.js
@@ -1,1024 +1,6447 @@
-/**
- * Polyfill from developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find
- */
-if (!Array.prototype.find) {
-  Array.prototype.find = function(predicate) {
-    if (this == null) {
-      throw new TypeError('Array.prototype.find called on null or undefined');
-    }
-    if (typeof predicate !== 'function') {
-      throw new TypeError('predicate must be a function');
-    }
-    var list = Object(this);
-    var length = list.length >>> 0;
-    var thisArg = arguments[1];
-    var value;
-
-    for (var i = 0; i < length; i++) {
-      value = list[i];
-      if (predicate.call(thisArg, value, i, list)) {
-        return value;
-      }
-    }
-    return undefined;
+var dav = (() => {
+  var __create = Object.create;
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getProtoOf = Object.getPrototypeOf;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __esm = (fn, res) => function __init() {
+    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
   };
-}
-/**
- * Polyfill from developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
- */
-if (!Object.assign) {
-  Object.defineProperty(Object, 'assign', {
-    enumerable: false,
-    configurable: true,
-    writable: true,
-    value: function(target, firstSource) {
-      'use strict';
-      if (target === undefined || target === null) {
-        throw new TypeError('Cannot convert first argument to object');
-      }
+  var __commonJS = (cb, mod) => function __require() {
+    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+  };
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+    // If the importer is in node compatibility mode or this is not an ESM
+    // file that has been converted to a CommonJS file using a Babel-
+    // compatible transform (i.e. "__esModule" has not been set), then set
+    // "default" to the CommonJS "module.exports" for node compatibility.
+    isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+    mod
+  ));
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
-      var to = Object(target);
-      for (var i = 1; i < arguments.length; i++) {
-        var nextSource = arguments[i];
-        if (nextSource === undefined || nextSource === null) {
-          continue;
-        }
-        nextSource = Object(nextSource);
-
-        var keysArray = Object.keys(Object(nextSource));
-        for (var nextIndex = 0, len = keysArray.length; nextIndex < len; nextIndex++) {
-          var nextKey = keysArray[nextIndex];
-          var desc = Object.getOwnPropertyDescriptor(nextSource, nextKey);
-          if (desc !== undefined && desc.enumerable) {
-            to[nextKey] = nextSource[nextKey];
+  // lib/debug.js
+  var require_debug = __commonJS({
+    "lib/debug.js"(exports, module) {
+      module.exports = function debug8(topic) {
+        return function(message) {
+          if (debug8.enabled) {
+            console.log(`[${topic}] ${message}`);
           }
-        }
-      }
-      return to;
+        };
+      };
     }
   });
-}
-/**
- * Copyright (c) 2014, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * https://raw.github.com/facebook/regenerator/master/LICENSE file. An
- * additional grant of patent rights can be found in the PATENTS file in
- * the same directory.
- */
 
-!(function(global) {
-  "use strict";
-
-  var hasOwn = Object.prototype.hasOwnProperty;
-  var undefined; // More compressible than void 0.
-  var iteratorSymbol =
-    typeof Symbol === "function" && Symbol.iterator || "@@iterator";
-
-  var inModule = typeof module === "object";
-  var runtime = global.regeneratorRuntime;
-  if (runtime) {
-    if (inModule) {
-      // If regeneratorRuntime is defined globally and we're in a module,
-      // make the exports object identical to regeneratorRuntime.
-      module.exports = runtime;
+  // lib/namespace.js
+  var namespace_exports = {};
+  __export(namespace_exports, {
+    CALDAV: () => CALDAV,
+    CALENDAR_SERVER: () => CALENDAR_SERVER,
+    CARDDAV: () => CARDDAV,
+    DAV: () => DAV,
+    OC: () => OC
+  });
+  var CALENDAR_SERVER, CALDAV, CARDDAV, DAV, OC;
+  var init_namespace = __esm({
+    "lib/namespace.js"() {
+      CALENDAR_SERVER = "http://calendarserver.org/ns/";
+      CALDAV = "urn:ietf:params:xml:ns:caldav";
+      CARDDAV = "urn:ietf:params:xml:ns:carddav";
+      DAV = "DAV:";
+      OC = "http://owncloud.org/ns";
     }
-    // Don't bother evaluating the rest of this file if the runtime was
-    // already defined globally.
-    return;
+  });
+
+  // lib/camelize.js
+  function camelize(str, delimiter = "_") {
+    let words = str.split(delimiter);
+    return [words[0]].concat(
+      words.slice(1).map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    ).join("");
   }
-
-  // Define the runtime globally (as expected by generated code) as either
-  // module.exports (if we're in a module) or a new, empty object.
-  runtime = global.regeneratorRuntime = inModule ? module.exports : {};
-
-  function wrap(innerFn, outerFn, self, tryLocsList) {
-    // If outerFn provided, then outerFn.prototype instanceof Generator.
-    var generator = Object.create((outerFn || Generator).prototype);
-
-    generator._invoke = makeInvokeMethod(
-      innerFn, self || null,
-      new Context(tryLocsList || [])
-    );
-
-    return generator;
-  }
-  runtime.wrap = wrap;
-
-  // Try/catch helper to minimize deoptimizations. Returns a completion
-  // record like context.tryEntries[i].completion. This interface could
-  // have been (and was previously) designed to take a closure to be
-  // invoked without arguments, but in all the cases we care about we
-  // already have an existing method we want to call, so there's no need
-  // to create a new function object. We can even get away with assuming
-  // the method takes exactly one argument, since that happens to be true
-  // in every case, so we don't have to touch the arguments object. The
-  // only additional allocation required is the completion record, which
-  // has a stable shape and so hopefully should be cheap to allocate.
-  function tryCatch(fn, obj, arg) {
-    try {
-      return { type: "normal", arg: fn.call(obj, arg) };
-    } catch (err) {
-      return { type: "throw", arg: err };
+  var init_camelize = __esm({
+    "lib/camelize.js"() {
     }
-  }
+  });
 
-  var GenStateSuspendedStart = "suspendedStart";
-  var GenStateSuspendedYield = "suspendedYield";
-  var GenStateExecuting = "executing";
-  var GenStateCompleted = "completed";
-
-  // Returning this object from the innerFn has the same effect as
-  // breaking out of the dispatch switch statement.
-  var ContinueSentinel = {};
-
-  // Dummy constructor functions that we use as the .constructor and
-  // .constructor.prototype properties for functions that return Generator
-  // objects. For full spec compliance, you may wish to configure your
-  // minifier not to mangle the names of these two functions.
-  function Generator() {}
-  function GeneratorFunction() {}
-  function GeneratorFunctionPrototype() {}
-
-  var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype;
-  GeneratorFunction.prototype = Gp.constructor = GeneratorFunctionPrototype;
-  GeneratorFunctionPrototype.constructor = GeneratorFunction;
-  GeneratorFunction.displayName = "GeneratorFunction";
-
-  runtime.isGeneratorFunction = function(genFun) {
-    var ctor = typeof genFun === "function" && genFun.constructor;
-    return ctor
-      ? ctor === GeneratorFunction ||
-        // For the native GeneratorFunction constructor, the best we can
-        // do is to check its .name property.
-        (ctor.displayName || ctor.name) === "GeneratorFunction"
-      : false;
-  };
-
-  runtime.mark = function(genFun) {
-    genFun.__proto__ = GeneratorFunctionPrototype;
-    genFun.prototype = Object.create(Gp);
-    return genFun;
-  };
-
-  runtime.async = function(innerFn, outerFn, self, tryLocsList) {
-    return new Promise(function(resolve, reject) {
-      var generator = wrap(innerFn, outerFn, self, tryLocsList);
-      var callNext = step.bind(generator, "next");
-      var callThrow = step.bind(generator, "throw");
-
-      function step(method, arg) {
-        var record = tryCatch(generator[method], generator, arg);
-        if (record.type === "throw") {
-          reject(record.arg);
-          return;
+  // node_modules/@xmldom/xmldom/lib/conventions.js
+  var require_conventions = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/conventions.js"(exports) {
+      "use strict";
+      function find(list, predicate, ac) {
+        if (ac === void 0) {
+          ac = Array.prototype;
         }
+        if (list && typeof ac.find === "function") {
+          return ac.find.call(list, predicate);
+        }
+        for (var i = 0; i < list.length; i++) {
+          if (Object.prototype.hasOwnProperty.call(list, i)) {
+            var item = list[i];
+            if (predicate.call(void 0, item, i, list)) {
+              return item;
+            }
+          }
+        }
+      }
+      function freeze(object, oc) {
+        if (oc === void 0) {
+          oc = Object;
+        }
+        return oc && typeof oc.freeze === "function" ? oc.freeze(object) : object;
+      }
+      function assign(target, source) {
+        if (target === null || typeof target !== "object") {
+          throw new TypeError("target is not an object");
+        }
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key];
+          }
+        }
+        return target;
+      }
+      var MIME_TYPE = freeze({
+        /**
+         * `text/html`, the only mime type that triggers treating an XML document as HTML.
+         *
+         * @see DOMParser.SupportedType.isHTML
+         * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
+         * @see https://en.wikipedia.org/wiki/HTML Wikipedia
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
+         * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring WHATWG HTML Spec
+         */
+        HTML: "text/html",
+        /**
+         * Helper method to check a mime type if it indicates an HTML document
+         *
+         * @param {string} [value]
+         * @returns {boolean}
+         *
+         * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
+         * @see https://en.wikipedia.org/wiki/HTML Wikipedia
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
+         * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring 	 */
+        isHTML: function(value) {
+          return value === MIME_TYPE.HTML;
+        },
+        /**
+         * `application/xml`, the standard mime type for XML documents.
+         *
+         * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType registration
+         * @see https://tools.ietf.org/html/rfc7303#section-9.1 RFC 7303
+         * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
+         */
+        XML_APPLICATION: "application/xml",
+        /**
+         * `text/html`, an alias for `application/xml`.
+         *
+         * @see https://tools.ietf.org/html/rfc7303#section-9.2 RFC 7303
+         * @see https://www.iana.org/assignments/media-types/text/xml IANA MimeType registration
+         * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
+         */
+        XML_TEXT: "text/xml",
+        /**
+         * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
+         * but is parsed as an XML document.
+         *
+         * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
+         * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
+         * @see https://en.wikipedia.org/wiki/XHTML Wikipedia
+         */
+        XML_XHTML_APPLICATION: "application/xhtml+xml",
+        /**
+         * `image/svg+xml`,
+         *
+         * @see https://www.iana.org/assignments/media-types/image/svg+xml IANA MimeType registration
+         * @see https://www.w3.org/TR/SVG11/ W3C SVG 1.1
+         * @see https://en.wikipedia.org/wiki/Scalable_Vector_Graphics Wikipedia
+         */
+        XML_SVG_IMAGE: "image/svg+xml"
+      });
+      var NAMESPACE = freeze({
+        /**
+         * The XHTML namespace.
+         *
+         * @see http://www.w3.org/1999/xhtml
+         */
+        HTML: "http://www.w3.org/1999/xhtml",
+        /**
+         * Checks if `uri` equals `NAMESPACE.HTML`.
+         *
+         * @param {string} [uri]
+         *
+         * @see NAMESPACE.HTML
+         */
+        isHTML: function(uri) {
+          return uri === NAMESPACE.HTML;
+        },
+        /**
+         * The SVG namespace.
+         *
+         * @see http://www.w3.org/2000/svg
+         */
+        SVG: "http://www.w3.org/2000/svg",
+        /**
+         * The `xml:` namespace.
+         *
+         * @see http://www.w3.org/XML/1998/namespace
+         */
+        XML: "http://www.w3.org/XML/1998/namespace",
+        /**
+         * The `xmlns:` namespace
+         *
+         * @see https://www.w3.org/2000/xmlns/
+         */
+        XMLNS: "http://www.w3.org/2000/xmlns/"
+      });
+      exports.assign = assign;
+      exports.find = find;
+      exports.freeze = freeze;
+      exports.MIME_TYPE = MIME_TYPE;
+      exports.NAMESPACE = NAMESPACE;
+    }
+  });
 
-        var info = record.arg;
-        if (info.done) {
-          resolve(info.value);
+  // node_modules/@xmldom/xmldom/lib/dom.js
+  var require_dom = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/dom.js"(exports) {
+      var conventions = require_conventions();
+      var find = conventions.find;
+      var NAMESPACE = conventions.NAMESPACE;
+      function notEmptyString(input) {
+        return input !== "";
+      }
+      function splitOnASCIIWhitespace(input) {
+        return input ? input.split(/[\t\n\f\r ]+/).filter(notEmptyString) : [];
+      }
+      function orderedSetReducer(current, element) {
+        if (!current.hasOwnProperty(element)) {
+          current[element] = true;
+        }
+        return current;
+      }
+      function toOrderedSet(input) {
+        if (!input) return [];
+        var list = splitOnASCIIWhitespace(input);
+        return Object.keys(list.reduce(orderedSetReducer, {}));
+      }
+      function arrayIncludes(list) {
+        return function(element) {
+          return list && list.indexOf(element) !== -1;
+        };
+      }
+      function copy(src, dest) {
+        for (var p in src) {
+          if (Object.prototype.hasOwnProperty.call(src, p)) {
+            dest[p] = src[p];
+          }
+        }
+      }
+      function _extends(Class, Super) {
+        var pt = Class.prototype;
+        if (!(pt instanceof Super)) {
+          let t2 = function() {
+          };
+          var t = t2;
+          ;
+          t2.prototype = Super.prototype;
+          t2 = new t2();
+          copy(pt, t2);
+          Class.prototype = pt = t2;
+        }
+        if (pt.constructor != Class) {
+          if (typeof Class != "function") {
+            console.error("unknown Class:" + Class);
+          }
+          pt.constructor = Class;
+        }
+      }
+      var NodeType = {};
+      var ELEMENT_NODE = NodeType.ELEMENT_NODE = 1;
+      var ATTRIBUTE_NODE = NodeType.ATTRIBUTE_NODE = 2;
+      var TEXT_NODE = NodeType.TEXT_NODE = 3;
+      var CDATA_SECTION_NODE = NodeType.CDATA_SECTION_NODE = 4;
+      var ENTITY_REFERENCE_NODE = NodeType.ENTITY_REFERENCE_NODE = 5;
+      var ENTITY_NODE = NodeType.ENTITY_NODE = 6;
+      var PROCESSING_INSTRUCTION_NODE = NodeType.PROCESSING_INSTRUCTION_NODE = 7;
+      var COMMENT_NODE = NodeType.COMMENT_NODE = 8;
+      var DOCUMENT_NODE = NodeType.DOCUMENT_NODE = 9;
+      var DOCUMENT_TYPE_NODE = NodeType.DOCUMENT_TYPE_NODE = 10;
+      var DOCUMENT_FRAGMENT_NODE = NodeType.DOCUMENT_FRAGMENT_NODE = 11;
+      var NOTATION_NODE = NodeType.NOTATION_NODE = 12;
+      var ExceptionCode = {};
+      var ExceptionMessage = {};
+      var INDEX_SIZE_ERR = ExceptionCode.INDEX_SIZE_ERR = (ExceptionMessage[1] = "Index size error", 1);
+      var DOMSTRING_SIZE_ERR = ExceptionCode.DOMSTRING_SIZE_ERR = (ExceptionMessage[2] = "DOMString size error", 2);
+      var HIERARCHY_REQUEST_ERR = ExceptionCode.HIERARCHY_REQUEST_ERR = (ExceptionMessage[3] = "Hierarchy request error", 3);
+      var WRONG_DOCUMENT_ERR = ExceptionCode.WRONG_DOCUMENT_ERR = (ExceptionMessage[4] = "Wrong document", 4);
+      var INVALID_CHARACTER_ERR = ExceptionCode.INVALID_CHARACTER_ERR = (ExceptionMessage[5] = "Invalid character", 5);
+      var NO_DATA_ALLOWED_ERR = ExceptionCode.NO_DATA_ALLOWED_ERR = (ExceptionMessage[6] = "No data allowed", 6);
+      var NO_MODIFICATION_ALLOWED_ERR = ExceptionCode.NO_MODIFICATION_ALLOWED_ERR = (ExceptionMessage[7] = "No modification allowed", 7);
+      var NOT_FOUND_ERR = ExceptionCode.NOT_FOUND_ERR = (ExceptionMessage[8] = "Not found", 8);
+      var NOT_SUPPORTED_ERR = ExceptionCode.NOT_SUPPORTED_ERR = (ExceptionMessage[9] = "Not supported", 9);
+      var INUSE_ATTRIBUTE_ERR = ExceptionCode.INUSE_ATTRIBUTE_ERR = (ExceptionMessage[10] = "Attribute in use", 10);
+      var INVALID_STATE_ERR = ExceptionCode.INVALID_STATE_ERR = (ExceptionMessage[11] = "Invalid state", 11);
+      var SYNTAX_ERR = ExceptionCode.SYNTAX_ERR = (ExceptionMessage[12] = "Syntax error", 12);
+      var INVALID_MODIFICATION_ERR = ExceptionCode.INVALID_MODIFICATION_ERR = (ExceptionMessage[13] = "Invalid modification", 13);
+      var NAMESPACE_ERR = ExceptionCode.NAMESPACE_ERR = (ExceptionMessage[14] = "Invalid namespace", 14);
+      var INVALID_ACCESS_ERR = ExceptionCode.INVALID_ACCESS_ERR = (ExceptionMessage[15] = "Invalid access", 15);
+      function DOMException(code, message) {
+        if (message instanceof Error) {
+          var error = message;
         } else {
-          Promise.resolve(info.value).then(callNext, callThrow);
+          error = this;
+          Error.call(this, ExceptionMessage[code]);
+          this.message = ExceptionMessage[code];
+          if (Error.captureStackTrace) Error.captureStackTrace(this, DOMException);
         }
+        error.code = code;
+        if (message) this.message = this.message + ": " + message;
+        return error;
       }
-
-      callNext();
-    });
-  };
-
-  function makeInvokeMethod(innerFn, self, context) {
-    var state = GenStateSuspendedStart;
-
-    return function invoke(method, arg) {
-      if (state === GenStateExecuting) {
-        throw new Error("Generator is already running");
+      DOMException.prototype = Error.prototype;
+      copy(ExceptionCode, DOMException);
+      function NodeList() {
       }
-
-      if (state === GenStateCompleted) {
-        // Be forgiving, per 25.3.3.3.3 of the spec:
-        // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-generatorresume
-        return doneResult();
+      NodeList.prototype = {
+        /**
+         * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
+         * @standard level1
+         */
+        length: 0,
+        /**
+         * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
+         * @standard level1
+         * @param index  unsigned long
+         *   Index into the collection.
+         * @return Node
+         * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
+         */
+        item: function(index) {
+          return index >= 0 && index < this.length ? this[index] : null;
+        },
+        toString: function(isHTML, nodeFilter, options) {
+          var requireWellFormed = !!options && !!options.requireWellFormed;
+          for (var buf = [], i = 0; i < this.length; i++) {
+            serializeToString(this[i], buf, isHTML, nodeFilter, null, requireWellFormed);
+          }
+          return buf.join("");
+        },
+        /**
+         * @private
+         * @param {function (Node):boolean} predicate
+         * @returns {Node[]}
+         */
+        filter: function(predicate) {
+          return Array.prototype.filter.call(this, predicate);
+        },
+        /**
+         * @private
+         * @param {Node} item
+         * @returns {number}
+         */
+        indexOf: function(item) {
+          return Array.prototype.indexOf.call(this, item);
+        }
+      };
+      function LiveNodeList(node, refresh) {
+        this._node = node;
+        this._refresh = refresh;
+        _updateLiveList(this);
       }
-
-      while (true) {
-        var delegate = context.delegate;
-        if (delegate) {
-          if (method === "return" ||
-              (method === "throw" && delegate.iterator[method] === undefined)) {
-            // A return or throw (when the delegate iterator has no throw
-            // method) always terminates the yield* loop.
-            context.delegate = null;
-
-            // If the delegate iterator has a return method, give it a
-            // chance to clean up.
-            var returnMethod = delegate.iterator["return"];
-            if (returnMethod) {
-              var record = tryCatch(returnMethod, delegate.iterator, arg);
-              if (record.type === "throw") {
-                // If the return method threw an exception, let that
-                // exception prevail over the original return or throw.
-                method = "throw";
-                arg = record.arg;
-                continue;
+      function _updateLiveList(list) {
+        var inc = list._node._inc || list._node.ownerDocument._inc;
+        if (list._inc !== inc) {
+          var ls = list._refresh(list._node);
+          __set__(list, "length", ls.length);
+          if (!list.$$length || ls.length < list.$$length) {
+            for (var i = ls.length; i in list; i++) {
+              if (Object.prototype.hasOwnProperty.call(list, i)) {
+                delete list[i];
               }
             }
-
-            if (method === "return") {
-              // Continue with the outer return, now that the delegate
-              // iterator has been terminated.
+          }
+          copy(ls, list);
+          list._inc = inc;
+        }
+      }
+      LiveNodeList.prototype.item = function(i) {
+        _updateLiveList(this);
+        return this[i] || null;
+      };
+      _extends(LiveNodeList, NodeList);
+      function NamedNodeMap() {
+      }
+      function _findNodeIndex(list, node) {
+        var i = list.length;
+        while (i--) {
+          if (list[i] === node) {
+            return i;
+          }
+        }
+      }
+      function _addNamedNode(el, list, newAttr, oldAttr) {
+        if (oldAttr) {
+          list[_findNodeIndex(list, oldAttr)] = newAttr;
+        } else {
+          list[list.length++] = newAttr;
+        }
+        if (el) {
+          newAttr.ownerElement = el;
+          var doc = el.ownerDocument;
+          if (doc) {
+            oldAttr && _onRemoveAttribute(doc, el, oldAttr);
+            _onAddAttribute(doc, el, newAttr);
+          }
+        }
+      }
+      function _removeNamedNode(el, list, attr) {
+        var i = _findNodeIndex(list, attr);
+        if (i >= 0) {
+          var lastIndex = list.length - 1;
+          while (i < lastIndex) {
+            list[i] = list[++i];
+          }
+          list.length = lastIndex;
+          if (el) {
+            var doc = el.ownerDocument;
+            if (doc) {
+              _onRemoveAttribute(doc, el, attr);
+              attr.ownerElement = null;
+            }
+          }
+        } else {
+          throw new DOMException(NOT_FOUND_ERR, new Error(el.tagName + "@" + attr));
+        }
+      }
+      NamedNodeMap.prototype = {
+        length: 0,
+        item: NodeList.prototype.item,
+        getNamedItem: function(key) {
+          var i = this.length;
+          while (i--) {
+            var attr = this[i];
+            if (attr.nodeName == key) {
+              return attr;
+            }
+          }
+        },
+        setNamedItem: function(attr) {
+          var el = attr.ownerElement;
+          if (el && el != this._ownerElement) {
+            throw new DOMException(INUSE_ATTRIBUTE_ERR);
+          }
+          var oldAttr = this.getNamedItem(attr.nodeName);
+          _addNamedNode(this._ownerElement, this, attr, oldAttr);
+          return oldAttr;
+        },
+        /* returns Node */
+        setNamedItemNS: function(attr) {
+          var el = attr.ownerElement, oldAttr;
+          if (el && el != this._ownerElement) {
+            throw new DOMException(INUSE_ATTRIBUTE_ERR);
+          }
+          oldAttr = this.getNamedItemNS(attr.namespaceURI, attr.localName);
+          _addNamedNode(this._ownerElement, this, attr, oldAttr);
+          return oldAttr;
+        },
+        /* returns Node */
+        removeNamedItem: function(key) {
+          var attr = this.getNamedItem(key);
+          _removeNamedNode(this._ownerElement, this, attr);
+          return attr;
+        },
+        // raises: NOT_FOUND_ERR,NO_MODIFICATION_ALLOWED_ERR
+        //for level2
+        removeNamedItemNS: function(namespaceURI, localName) {
+          var attr = this.getNamedItemNS(namespaceURI, localName);
+          _removeNamedNode(this._ownerElement, this, attr);
+          return attr;
+        },
+        getNamedItemNS: function(namespaceURI, localName) {
+          var i = this.length;
+          while (i--) {
+            var node = this[i];
+            if (node.localName == localName && node.namespaceURI == namespaceURI) {
+              return node;
+            }
+          }
+          return null;
+        }
+      };
+      function DOMImplementation() {
+      }
+      DOMImplementation.prototype = {
+        /**
+         * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported.
+         * The different implementations fairly diverged in what kind of features were reported.
+         * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in use.
+         *
+         * @deprecated It is deprecated and modern browsers return true in all cases.
+         *
+         * @param {string} feature
+         * @param {string} [version]
+         * @returns {boolean} always true
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
+         * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
+         * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
+         */
+        hasFeature: function(feature, version2) {
+          return true;
+        },
+        /**
+         * Creates an XML Document object of the specified type with its document element.
+         *
+         * __It behaves slightly different from the description in the living standard__:
+         * - There is no interface/class `XMLDocument`, it returns a `Document` instance.
+         * - `contentType`, `encoding`, `mode`, `origin`, `url` fields are currently not declared.
+         * - this implementation is not validating names or qualified names
+         *   (when parsing XML strings, the SAX parser takes care of that)
+         *
+         * @param {string|null} namespaceURI
+         * @param {string} qualifiedName
+         * @param {DocumentType=null} doctype
+         * @returns {Document}
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
+         * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
+         * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument  DOM Level 2 Core
+         *
+         * @see https://dom.spec.whatwg.org/#validate-and-extract DOM: Validate and extract
+         * @see https://www.w3.org/TR/xml/#NT-NameStartChar XML Spec: Names
+         * @see https://www.w3.org/TR/xml-names/#ns-qualnames XML Namespaces: Qualified names
+         */
+        createDocument: function(namespaceURI, qualifiedName, doctype) {
+          var doc = new Document();
+          doc.implementation = this;
+          doc.childNodes = new NodeList();
+          doc.doctype = doctype || null;
+          if (doctype) {
+            doc.appendChild(doctype);
+          }
+          if (qualifiedName) {
+            var root = doc.createElementNS(namespaceURI, qualifiedName);
+            doc.appendChild(root);
+          }
+          return doc;
+        },
+        /**
+         * Returns a doctype, with the given `qualifiedName`, `publicId`, and `systemId`.
+         *
+         * __This implementation differs from the specification:__
+         * - this implementation is not validating names or qualified names
+         *   (when parsing XML strings, the SAX parser takes care of that)
+         *
+         * Note: `internalSubset` can only be introduced via a direct property write to `node.internalSubset` after creation.
+         * Creation-time validation of `publicId`, `systemId` is not enforced.
+         * The serializer-level check covers all mutation vectors, including direct property writes.
+         * `internalSubset` is only serialized as `[ ... ]` when both `publicId` and `systemId` are
+         * absent (empty or `'.'`) — if either external identifier is present, `internalSubset` is
+         * silently omitted from the serialized output.
+         *
+         * @param {string} qualifiedName
+         * @param {string} [publicId]
+         * The external subset public identifier. Stored verbatim including surrounding quotes.
+         * When serialized with `requireWellFormed: true` (via the 4th-parameter options object),
+         * throws `DOMException` with code `INVALID_STATE_ERR` if the value is non-empty and does
+         * not match the XML `PubidLiteral` production (W3C DOM Parsing §3.2.1.3; XML 1.0 [12]).
+         * @param {string} [systemId]
+         * The external subset system identifier. Stored verbatim including surrounding quotes.
+         * When serialized with `requireWellFormed: true`, throws `DOMException` with code
+         * `INVALID_STATE_ERR` if the value is non-empty and does not match the XML `SystemLiteral`
+         * production (W3C DOM Parsing §3.2.1.3; XML 1.0 [11]).
+         * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument` upon document creation
+         * 				  or can be put into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
+         * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
+         * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
+         *
+         * @see https://dom.spec.whatwg.org/#validate-and-extract DOM: Validate and extract
+         * @see https://www.w3.org/TR/xml/#NT-NameStartChar XML Spec: Names
+         * @see https://www.w3.org/TR/xml-names/#ns-qualnames XML Namespaces: Qualified names
+         */
+        createDocumentType: function(qualifiedName, publicId, systemId) {
+          var node = new DocumentType();
+          node.name = qualifiedName;
+          node.nodeName = qualifiedName;
+          node.publicId = publicId || "";
+          node.systemId = systemId || "";
+          return node;
+        }
+      };
+      function Node() {
+      }
+      Node.prototype = {
+        firstChild: null,
+        lastChild: null,
+        previousSibling: null,
+        nextSibling: null,
+        attributes: null,
+        parentNode: null,
+        childNodes: null,
+        ownerDocument: null,
+        nodeValue: null,
+        namespaceURI: null,
+        prefix: null,
+        localName: null,
+        // Modified in DOM Level 2:
+        insertBefore: function(newChild, refChild) {
+          return _insertBefore(this, newChild, refChild);
+        },
+        replaceChild: function(newChild, oldChild) {
+          _insertBefore(this, newChild, oldChild, assertPreReplacementValidityInDocument);
+          if (oldChild) {
+            this.removeChild(oldChild);
+          }
+        },
+        removeChild: function(oldChild) {
+          return _removeChild(this, oldChild);
+        },
+        appendChild: function(newChild) {
+          return this.insertBefore(newChild, null);
+        },
+        hasChildNodes: function() {
+          return this.firstChild != null;
+        },
+        cloneNode: function(deep) {
+          return cloneNode(this.ownerDocument || this, this, deep);
+        },
+        // Modified in DOM Level 2:
+        /**
+         * Puts the specified node and all of its subtree into a "normalized" form. In a normalized
+         * subtree, no text nodes in the subtree are empty and there are no adjacent text nodes.
+         *
+         * Specifically, this method merges any adjacent text nodes (i.e., nodes for which `nodeType`
+         * is `TEXT_NODE`) into a single node with the combined data. It also removes any empty text
+         * nodes.
+         *
+         * This method iteratively traverses all child nodes to normalize all descendant nodes within
+         * the subtree.
+         *
+         * @throws {DOMException}
+         * May throw a DOMException if operations within removeChild or appendData (which are
+         * potentially invoked in this method) do not meet their specific constraints.
+         * @see {@link Node.removeChild}
+         * @see {@link CharacterData.appendData}
+         * @see ../docs/walk-dom.md.
+         */
+        normalize: function() {
+          walkDOM(this, null, {
+            enter: function(node) {
+              var child2 = node.firstChild;
+              while (child2) {
+                var next = child2.nextSibling;
+                if (next !== null && next.nodeType === TEXT_NODE && child2.nodeType === TEXT_NODE) {
+                  node.removeChild(next);
+                  child2.appendData(next.data);
+                } else {
+                  child2 = next;
+                }
+              }
+              return true;
+            }
+          });
+        },
+        // Introduced in DOM Level 2:
+        isSupported: function(feature, version2) {
+          return this.ownerDocument.implementation.hasFeature(feature, version2);
+        },
+        // Introduced in DOM Level 2:
+        hasAttributes: function() {
+          return this.attributes.length > 0;
+        },
+        /**
+         * Look up the prefix associated to the given namespace URI, starting from this node.
+         * **The default namespace declarations are ignored by this method.**
+         * See Namespace Prefix Lookup for details on the algorithm used by this method.
+         *
+         * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
+         *
+         * @param {string | null} namespaceURI
+         * @returns {string | null}
+         * @see https://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespacePrefix
+         * @see https://www.w3.org/TR/DOM-Level-3-Core/namespaces-algorithms.html#lookupNamespacePrefixAlgo
+         * @see https://dom.spec.whatwg.org/#dom-node-lookupprefix
+         * @see https://github.com/xmldom/xmldom/issues/322
+         */
+        lookupPrefix: function(namespaceURI) {
+          var el = this;
+          while (el) {
+            var map = el._nsMap;
+            if (map) {
+              for (var n in map) {
+                if (Object.prototype.hasOwnProperty.call(map, n) && map[n] === namespaceURI) {
+                  return n;
+                }
+              }
+            }
+            el = el.nodeType == ATTRIBUTE_NODE ? el.ownerDocument : el.parentNode;
+          }
+          return null;
+        },
+        // Introduced in DOM Level 3:
+        lookupNamespaceURI: function(prefix) {
+          var el = this;
+          while (el) {
+            var map = el._nsMap;
+            if (map) {
+              if (Object.prototype.hasOwnProperty.call(map, prefix)) {
+                return map[prefix];
+              }
+            }
+            el = el.nodeType == ATTRIBUTE_NODE ? el.ownerDocument : el.parentNode;
+          }
+          return null;
+        },
+        // Introduced in DOM Level 3:
+        isDefaultNamespace: function(namespaceURI) {
+          var prefix = this.lookupPrefix(namespaceURI);
+          return prefix == null;
+        }
+      };
+      function _xmlEncoder(c) {
+        return c == "<" && "&lt;" || c == ">" && "&gt;" || c == "&" && "&amp;" || c == '"' && "&quot;" || "&#" + c.charCodeAt() + ";";
+      }
+      copy(NodeType, Node);
+      copy(NodeType, Node.prototype);
+      function _visitNode(node, callback) {
+        return walkDOM(node, null, { enter: function(n) {
+          return callback(n) ? walkDOM.STOP : true;
+        } }) === walkDOM.STOP;
+      }
+      function walkDOM(node, context, callbacks) {
+        var stack = [{ node, context, phase: walkDOM.ENTER }];
+        while (stack.length > 0) {
+          var frame = stack.pop();
+          if (frame.phase === walkDOM.ENTER) {
+            var childContext = callbacks.enter(frame.node, frame.context);
+            if (childContext === walkDOM.STOP) {
+              return walkDOM.STOP;
+            }
+            stack.push({ node: frame.node, context: childContext, phase: walkDOM.EXIT });
+            if (childContext === null || childContext === void 0) {
               continue;
             }
+            var child2 = frame.node.lastChild;
+            while (child2) {
+              stack.push({ node: child2, context: childContext, phase: walkDOM.ENTER });
+              child2 = child2.previousSibling;
+            }
+          } else {
+            if (callbacks.exit) {
+              callbacks.exit(frame.node, frame.context);
+            }
           }
-
-          var record = tryCatch(
-            delegate.iterator[method],
-            delegate.iterator,
-            arg
+        }
+      }
+      walkDOM.STOP = Symbol("walkDOM.STOP");
+      walkDOM.ENTER = 0;
+      walkDOM.EXIT = 1;
+      function Document() {
+        this.ownerDocument = this;
+      }
+      function _onAddAttribute(doc, el, newAttr) {
+        doc && doc._inc++;
+        var ns = newAttr.namespaceURI;
+        if (ns === NAMESPACE.XMLNS) {
+          el._nsMap[newAttr.prefix ? newAttr.localName : ""] = newAttr.value;
+        }
+      }
+      function _onRemoveAttribute(doc, el, newAttr, remove) {
+        doc && doc._inc++;
+        var ns = newAttr.namespaceURI;
+        if (ns === NAMESPACE.XMLNS) {
+          delete el._nsMap[newAttr.prefix ? newAttr.localName : ""];
+        }
+      }
+      function _onUpdateChild(doc, el, newChild) {
+        if (doc && doc._inc) {
+          doc._inc++;
+          var cs = el.childNodes;
+          if (newChild) {
+            cs[cs.length++] = newChild;
+          } else {
+            var child2 = el.firstChild;
+            var i = 0;
+            while (child2) {
+              cs[i++] = child2;
+              child2 = child2.nextSibling;
+            }
+            cs.length = i;
+            delete cs[cs.length];
+          }
+        }
+      }
+      function _removeChild(parentNode, child2) {
+        var previous = child2.previousSibling;
+        var next = child2.nextSibling;
+        if (previous) {
+          previous.nextSibling = next;
+        } else {
+          parentNode.firstChild = next;
+        }
+        if (next) {
+          next.previousSibling = previous;
+        } else {
+          parentNode.lastChild = previous;
+        }
+        child2.parentNode = null;
+        child2.previousSibling = null;
+        child2.nextSibling = null;
+        _onUpdateChild(parentNode.ownerDocument, parentNode);
+        return child2;
+      }
+      function hasValidParentNodeType(node) {
+        return node && (node.nodeType === Node.DOCUMENT_NODE || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE || node.nodeType === Node.ELEMENT_NODE);
+      }
+      function hasInsertableNodeType(node) {
+        return node && (isElementNode(node) || isTextNode(node) || isDocTypeNode(node) || node.nodeType === Node.DOCUMENT_FRAGMENT_NODE || node.nodeType === Node.COMMENT_NODE || node.nodeType === Node.PROCESSING_INSTRUCTION_NODE);
+      }
+      function isDocTypeNode(node) {
+        return node && node.nodeType === Node.DOCUMENT_TYPE_NODE;
+      }
+      function isElementNode(node) {
+        return node && node.nodeType === Node.ELEMENT_NODE;
+      }
+      function isTextNode(node) {
+        return node && node.nodeType === Node.TEXT_NODE;
+      }
+      function isElementInsertionPossible(doc, child2) {
+        var parentChildNodes = doc.childNodes || [];
+        if (find(parentChildNodes, isElementNode) || isDocTypeNode(child2)) {
+          return false;
+        }
+        var docTypeNode = find(parentChildNodes, isDocTypeNode);
+        return !(child2 && docTypeNode && parentChildNodes.indexOf(docTypeNode) > parentChildNodes.indexOf(child2));
+      }
+      function isElementReplacementPossible(doc, child2) {
+        var parentChildNodes = doc.childNodes || [];
+        function hasElementChildThatIsNotChild(node) {
+          return isElementNode(node) && node !== child2;
+        }
+        if (find(parentChildNodes, hasElementChildThatIsNotChild)) {
+          return false;
+        }
+        var docTypeNode = find(parentChildNodes, isDocTypeNode);
+        return !(child2 && docTypeNode && parentChildNodes.indexOf(docTypeNode) > parentChildNodes.indexOf(child2));
+      }
+      function assertPreInsertionValidity1to5(parent, node, child2) {
+        if (!hasValidParentNodeType(parent)) {
+          throw new DOMException(HIERARCHY_REQUEST_ERR, "Unexpected parent node type " + parent.nodeType);
+        }
+        if (child2 && child2.parentNode !== parent) {
+          throw new DOMException(NOT_FOUND_ERR, "child not in parent");
+        }
+        if (
+          // 4. If `node` is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
+          !hasInsertableNodeType(node) || // 5. If either `node` is a Text node and `parent` is a document,
+          // the sax parser currently adds top level text nodes, this will be fixed in 0.9.0
+          // || (node.nodeType === Node.TEXT_NODE && parent.nodeType === Node.DOCUMENT_NODE)
+          // or `node` is a doctype and `parent` is not a document, then throw a "HierarchyRequestError" DOMException.
+          isDocTypeNode(node) && parent.nodeType !== Node.DOCUMENT_NODE
+        ) {
+          throw new DOMException(
+            HIERARCHY_REQUEST_ERR,
+            "Unexpected node type " + node.nodeType + " for parent node type " + parent.nodeType
           );
-
-          if (record.type === "throw") {
-            context.delegate = null;
-
-            // Like returning generator.throw(uncaught), but without the
-            // overhead of an extra function call.
-            method = "throw";
-            arg = record.arg;
-            continue;
-          }
-
-          // Delegate generator ran and handled its own exceptions so
-          // regardless of what the method was, we continue as if it is
-          // "next" with an undefined arg.
-          method = "next";
-          arg = undefined;
-
-          var info = record.arg;
-          if (info.done) {
-            context[delegate.resultName] = info.value;
-            context.next = delegate.nextLoc;
-          } else {
-            state = GenStateSuspendedYield;
-            return info;
-          }
-
-          context.delegate = null;
         }
-
-        if (method === "next") {
-          if (state === GenStateSuspendedYield) {
-            context.sent = arg;
-          } else {
-            delete context.sent;
+      }
+      function assertPreInsertionValidityInDocument(parent, node, child2) {
+        var parentChildNodes = parent.childNodes || [];
+        var nodeChildNodes = node.childNodes || [];
+        if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+          var nodeChildElements = nodeChildNodes.filter(isElementNode);
+          if (nodeChildElements.length > 1 || find(nodeChildNodes, isTextNode)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "More than one element or text in fragment");
           }
-
-        } else if (method === "throw") {
-          if (state === GenStateSuspendedStart) {
-            state = GenStateCompleted;
-            throw arg;
+          if (nodeChildElements.length === 1 && !isElementInsertionPossible(parent, child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Element in fragment can not be inserted before doctype");
           }
-
-          if (context.dispatchException(arg)) {
-            // If the dispatched exception was caught by a catch block,
-            // then let that catch block handle the exception normally.
-            method = "next";
-            arg = undefined;
-          }
-
-        } else if (method === "return") {
-          context.abrupt("return", arg);
         }
-
-        state = GenStateExecuting;
-
-        var record = tryCatch(innerFn, self, context);
-        if (record.type === "normal") {
-          // If an exception is thrown from innerFn, we leave state ===
-          // GenStateExecuting and loop back for another invocation.
-          state = context.done
-            ? GenStateCompleted
-            : GenStateSuspendedYield;
-
-          var info = {
-            value: record.arg,
-            done: context.done
+        if (isElementNode(node)) {
+          if (!isElementInsertionPossible(parent, child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Only one element can be added and only after doctype");
+          }
+        }
+        if (isDocTypeNode(node)) {
+          if (find(parentChildNodes, isDocTypeNode)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Only one doctype is allowed");
+          }
+          var parentElementChild = find(parentChildNodes, isElementNode);
+          if (child2 && parentChildNodes.indexOf(parentElementChild) < parentChildNodes.indexOf(child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Doctype can only be inserted before an element");
+          }
+          if (!child2 && parentElementChild) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Doctype can not be appended since element is present");
+          }
+        }
+      }
+      function assertPreReplacementValidityInDocument(parent, node, child2) {
+        var parentChildNodes = parent.childNodes || [];
+        var nodeChildNodes = node.childNodes || [];
+        if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+          var nodeChildElements = nodeChildNodes.filter(isElementNode);
+          if (nodeChildElements.length > 1 || find(nodeChildNodes, isTextNode)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "More than one element or text in fragment");
+          }
+          if (nodeChildElements.length === 1 && !isElementReplacementPossible(parent, child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Element in fragment can not be inserted before doctype");
+          }
+        }
+        if (isElementNode(node)) {
+          if (!isElementReplacementPossible(parent, child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Only one element can be added and only after doctype");
+          }
+        }
+        if (isDocTypeNode(node)) {
+          let hasDoctypeChildThatIsNotChild2 = function(node2) {
+            return isDocTypeNode(node2) && node2 !== child2;
           };
-
-          if (record.arg === ContinueSentinel) {
-            if (context.delegate && method === "next") {
-              // Deliberately forget the last sent value so that we don't
-              // accidentally pass it on to the delegate.
-              arg = undefined;
+          var hasDoctypeChildThatIsNotChild = hasDoctypeChildThatIsNotChild2;
+          if (find(parentChildNodes, hasDoctypeChildThatIsNotChild2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Only one doctype is allowed");
+          }
+          var parentElementChild = find(parentChildNodes, isElementNode);
+          if (child2 && parentChildNodes.indexOf(parentElementChild) < parentChildNodes.indexOf(child2)) {
+            throw new DOMException(HIERARCHY_REQUEST_ERR, "Doctype can only be inserted before an element");
+          }
+        }
+      }
+      function _insertBefore(parent, node, child2, _inDocumentAssertion) {
+        assertPreInsertionValidity1to5(parent, node, child2);
+        if (parent.nodeType === Node.DOCUMENT_NODE) {
+          (_inDocumentAssertion || assertPreInsertionValidityInDocument)(parent, node, child2);
+        }
+        var cp = node.parentNode;
+        if (cp) {
+          cp.removeChild(node);
+        }
+        if (node.nodeType === DOCUMENT_FRAGMENT_NODE) {
+          var newFirst = node.firstChild;
+          if (newFirst == null) {
+            return node;
+          }
+          var newLast = node.lastChild;
+        } else {
+          newFirst = newLast = node;
+        }
+        var pre = child2 ? child2.previousSibling : parent.lastChild;
+        newFirst.previousSibling = pre;
+        newLast.nextSibling = child2;
+        if (pre) {
+          pre.nextSibling = newFirst;
+        } else {
+          parent.firstChild = newFirst;
+        }
+        if (child2 == null) {
+          parent.lastChild = newLast;
+        } else {
+          child2.previousSibling = newLast;
+        }
+        do {
+          newFirst.parentNode = parent;
+          var targetDoc = parent.ownerDocument || parent;
+          _updateOwnerDocument(newFirst, targetDoc);
+        } while (newFirst !== newLast && (newFirst = newFirst.nextSibling));
+        _onUpdateChild(parent.ownerDocument || parent, parent);
+        if (node.nodeType == DOCUMENT_FRAGMENT_NODE) {
+          node.firstChild = node.lastChild = null;
+        }
+        return node;
+      }
+      function _updateOwnerDocument(node, newOwnerDocument) {
+        if (node.ownerDocument === newOwnerDocument) {
+          return;
+        }
+        node.ownerDocument = newOwnerDocument;
+        if (node.nodeType === ELEMENT_NODE && node.attributes) {
+          for (var i = 0; i < node.attributes.length; i++) {
+            var attr = node.attributes.item(i);
+            if (attr) {
+              attr.ownerDocument = newOwnerDocument;
             }
+          }
+        }
+        var child2 = node.firstChild;
+        while (child2) {
+          _updateOwnerDocument(child2, newOwnerDocument);
+          child2 = child2.nextSibling;
+        }
+      }
+      function _appendSingleChild(parentNode, newChild) {
+        if (newChild.parentNode) {
+          newChild.parentNode.removeChild(newChild);
+        }
+        newChild.parentNode = parentNode;
+        newChild.previousSibling = parentNode.lastChild;
+        newChild.nextSibling = null;
+        if (newChild.previousSibling) {
+          newChild.previousSibling.nextSibling = newChild;
+        } else {
+          parentNode.firstChild = newChild;
+        }
+        parentNode.lastChild = newChild;
+        _onUpdateChild(parentNode.ownerDocument, parentNode, newChild);
+        var targetDoc = parentNode.ownerDocument || parentNode;
+        _updateOwnerDocument(newChild, targetDoc);
+        return newChild;
+      }
+      Document.prototype = {
+        //implementation : null,
+        nodeName: "#document",
+        nodeType: DOCUMENT_NODE,
+        /**
+         * The DocumentType node of the document.
+         *
+         * @readonly
+         * @type DocumentType
+         */
+        doctype: null,
+        documentElement: null,
+        _inc: 1,
+        insertBefore: function(newChild, refChild) {
+          if (newChild.nodeType == DOCUMENT_FRAGMENT_NODE) {
+            var child2 = newChild.firstChild;
+            while (child2) {
+              var next = child2.nextSibling;
+              this.insertBefore(child2, refChild);
+              child2 = next;
+            }
+            return newChild;
+          }
+          _insertBefore(this, newChild, refChild);
+          _updateOwnerDocument(newChild, this);
+          if (this.documentElement === null && newChild.nodeType === ELEMENT_NODE) {
+            this.documentElement = newChild;
+          }
+          return newChild;
+        },
+        removeChild: function(oldChild) {
+          if (this.documentElement == oldChild) {
+            this.documentElement = null;
+          }
+          return _removeChild(this, oldChild);
+        },
+        replaceChild: function(newChild, oldChild) {
+          _insertBefore(this, newChild, oldChild, assertPreReplacementValidityInDocument);
+          _updateOwnerDocument(newChild, this);
+          if (oldChild) {
+            this.removeChild(oldChild);
+          }
+          if (isElementNode(newChild)) {
+            this.documentElement = newChild;
+          }
+        },
+        // Introduced in DOM Level 2:
+        importNode: function(importedNode, deep) {
+          return importNode(this, importedNode, deep);
+        },
+        // Introduced in DOM Level 2:
+        getElementById: function(id) {
+          var rtv = null;
+          _visitNode(this.documentElement, function(node) {
+            if (node.nodeType == ELEMENT_NODE) {
+              if (node.getAttribute("id") == id) {
+                rtv = node;
+                return true;
+              }
+            }
+          });
+          return rtv;
+        },
+        /**
+         * The `getElementsByClassName` method of `Document` interface returns an array-like object
+         * of all child elements which have **all** of the given class name(s).
+         *
+         * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
+         *
+         *
+         * Warning: This is a live LiveNodeList.
+         * Changes in the DOM will reflect in the array as the changes occur.
+         * If an element selected by this array no longer qualifies for the selector,
+         * it will automatically be removed. Be aware of this for iteration purposes.
+         *
+         * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
+         *
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
+         * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
+         */
+        getElementsByClassName: function(classNames) {
+          var classNamesSet = toOrderedSet(classNames);
+          return new LiveNodeList(this, function(base) {
+            var ls = [];
+            if (classNamesSet.length > 0) {
+              _visitNode(base.documentElement, function(node) {
+                if (node !== base && node.nodeType === ELEMENT_NODE) {
+                  var nodeClassNames = node.getAttribute("class");
+                  if (nodeClassNames) {
+                    var matches = classNames === nodeClassNames;
+                    if (!matches) {
+                      var nodeClassNamesSet = toOrderedSet(nodeClassNames);
+                      matches = classNamesSet.every(arrayIncludes(nodeClassNamesSet));
+                    }
+                    if (matches) {
+                      ls.push(node);
+                    }
+                  }
+                }
+              });
+            }
+            return ls;
+          });
+        },
+        //document factory method:
+        createElement: function(tagName) {
+          var node = new Element();
+          node.ownerDocument = this;
+          node.nodeName = tagName;
+          node.tagName = tagName;
+          node.localName = tagName;
+          node.childNodes = new NodeList();
+          var attrs = node.attributes = new NamedNodeMap();
+          attrs._ownerElement = node;
+          return node;
+        },
+        createDocumentFragment: function() {
+          var node = new DocumentFragment();
+          node.ownerDocument = this;
+          node.childNodes = new NodeList();
+          return node;
+        },
+        createTextNode: function(data) {
+          var node = new Text();
+          node.ownerDocument = this;
+          node.appendData(data);
+          return node;
+        },
+        createComment: function(data) {
+          var node = new Comment();
+          node.ownerDocument = this;
+          node.appendData(data);
+          return node;
+        },
+        /**
+         * Returns a new CDATASection node whose data is `data`.
+         *
+         * __This implementation differs from the specification:__
+         * - calling this method on an HTML document does not throw `NotSupportedError`.
+         *
+         * @param {string} data
+         * @returns {CDATASection}
+         * @throws DOMException with code `INVALID_CHARACTER_ERR` if `data` contains `"]]>"`.
+         * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createCDATASection
+         * @see https://dom.spec.whatwg.org/#dom-document-createcdatasection
+         */
+        createCDATASection: function(data) {
+          if (data.indexOf("]]>") !== -1) {
+            throw new DOMException(INVALID_CHARACTER_ERR, 'data contains "]]>"');
+          }
+          var node = new CDATASection();
+          node.ownerDocument = this;
+          node.appendData(data);
+          return node;
+        },
+        /**
+         * Returns a ProcessingInstruction node whose target is target and data is data.
+         *
+         * __This implementation differs from the specification:__
+         * - it does not do any input validation on the arguments and doesn't throw "InvalidCharacterError".
+         *
+         * Note: When the resulting document is serialized with `requireWellFormed: true`, the
+         * serializer throws with code `INVALID_STATE_ERR` if `.data` contains `?>` (W3C DOM Parsing
+         * §3.2.1.7). Without that option the data is emitted verbatim.
+         *
+         * @param {string} target
+         * @param {string} data
+         * @returns {ProcessingInstruction}
+         * @see https://developer.mozilla.org/docs/Web/API/Document/createProcessingInstruction
+         * @see https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
+         * @see https://www.w3.org/TR/DOM-Parsing/#dfn-concept-serialize-xml §3.2.1.7
+         */
+        createProcessingInstruction: function(target, data) {
+          var node = new ProcessingInstruction();
+          node.ownerDocument = this;
+          node.tagName = node.nodeName = node.target = target;
+          node.nodeValue = node.data = data;
+          return node;
+        },
+        createAttribute: function(name) {
+          var node = new Attr();
+          node.ownerDocument = this;
+          node.name = name;
+          node.nodeName = name;
+          node.localName = name;
+          node.specified = true;
+          return node;
+        },
+        createEntityReference: function(name) {
+          var node = new EntityReference();
+          node.ownerDocument = this;
+          node.nodeName = name;
+          return node;
+        },
+        // Introduced in DOM Level 2:
+        createElementNS: function(namespaceURI, qualifiedName) {
+          var node = new Element();
+          var pl = qualifiedName.split(":");
+          var attrs = node.attributes = new NamedNodeMap();
+          node.childNodes = new NodeList();
+          node.ownerDocument = this;
+          node.nodeName = qualifiedName;
+          node.tagName = qualifiedName;
+          node.namespaceURI = namespaceURI;
+          if (pl.length == 2) {
+            node.prefix = pl[0];
+            node.localName = pl[1];
           } else {
-            return info;
+            node.localName = qualifiedName;
           }
-
-        } else if (record.type === "throw") {
-          state = GenStateCompleted;
-          // Dispatch the exception by looping back around to the
-          // context.dispatchException(arg) call above.
-          method = "throw";
-          arg = record.arg;
-        }
-      }
-    };
-  }
-
-  function defineGeneratorMethod(method) {
-    Gp[method] = function(arg) {
-      return this._invoke(method, arg);
-    };
-  }
-  defineGeneratorMethod("next");
-  defineGeneratorMethod("throw");
-  defineGeneratorMethod("return");
-
-  Gp[iteratorSymbol] = function() {
-    return this;
-  };
-
-  Gp.toString = function() {
-    return "[object Generator]";
-  };
-
-  function pushTryEntry(locs) {
-    var entry = { tryLoc: locs[0] };
-
-    if (1 in locs) {
-      entry.catchLoc = locs[1];
-    }
-
-    if (2 in locs) {
-      entry.finallyLoc = locs[2];
-      entry.afterLoc = locs[3];
-    }
-
-    this.tryEntries.push(entry);
-  }
-
-  function resetTryEntry(entry) {
-    var record = entry.completion || {};
-    record.type = "normal";
-    delete record.arg;
-    entry.completion = record;
-  }
-
-  function Context(tryLocsList) {
-    // The root entry object (effectively a try statement without a catch
-    // or a finally block) gives us a place to store values thrown from
-    // locations where there is no enclosing try statement.
-    this.tryEntries = [{ tryLoc: "root" }];
-    tryLocsList.forEach(pushTryEntry, this);
-    this.reset();
-  }
-
-  runtime.keys = function(object) {
-    var keys = [];
-    for (var key in object) {
-      keys.push(key);
-    }
-    keys.reverse();
-
-    // Rather than returning an object with a next method, we keep
-    // things simple and return the next function itself.
-    return function next() {
-      while (keys.length) {
-        var key = keys.pop();
-        if (key in object) {
-          next.value = key;
-          next.done = false;
-          return next;
-        }
-      }
-
-      // To avoid creating an additional object, we just hang the .value
-      // and .done properties off the next function object itself. This
-      // also ensures that the minifier will not anonymize the function.
-      next.done = true;
-      return next;
-    };
-  };
-
-  function values(iterable) {
-    if (iterable) {
-      var iteratorMethod = iterable[iteratorSymbol];
-      if (iteratorMethod) {
-        return iteratorMethod.call(iterable);
-      }
-
-      if (typeof iterable.next === "function") {
-        return iterable;
-      }
-
-      if (!isNaN(iterable.length)) {
-        var i = -1, next = function next() {
-          while (++i < iterable.length) {
-            if (hasOwn.call(iterable, i)) {
-              next.value = iterable[i];
-              next.done = false;
-              return next;
-            }
-          }
-
-          next.value = undefined;
-          next.done = true;
-
-          return next;
-        };
-
-        return next.next = next;
-      }
-    }
-
-    // Return an iterator with no values.
-    return { next: doneResult };
-  }
-  runtime.values = values;
-
-  function doneResult() {
-    return { value: undefined, done: true };
-  }
-
-  Context.prototype = {
-    constructor: Context,
-
-    reset: function() {
-      this.prev = 0;
-      this.next = 0;
-      this.sent = undefined;
-      this.done = false;
-      this.delegate = null;
-
-      this.tryEntries.forEach(resetTryEntry);
-
-      // Pre-initialize at least 20 temporary variables to enable hidden
-      // class optimizations for simple generators.
-      for (var tempIndex = 0, tempName;
-           hasOwn.call(this, tempName = "t" + tempIndex) || tempIndex < 20;
-           ++tempIndex) {
-        this[tempName] = null;
-      }
-    },
-
-    stop: function() {
-      this.done = true;
-
-      var rootEntry = this.tryEntries[0];
-      var rootRecord = rootEntry.completion;
-      if (rootRecord.type === "throw") {
-        throw rootRecord.arg;
-      }
-
-      return this.rval;
-    },
-
-    dispatchException: function(exception) {
-      if (this.done) {
-        throw exception;
-      }
-
-      var context = this;
-      function handle(loc, caught) {
-        record.type = "throw";
-        record.arg = exception;
-        context.next = loc;
-        return !!caught;
-      }
-
-      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
-        var entry = this.tryEntries[i];
-        var record = entry.completion;
-
-        if (entry.tryLoc === "root") {
-          // Exception thrown outside of any try block that could handle
-          // it, so set the completion value of the entire function to
-          // throw the exception.
-          return handle("end");
-        }
-
-        if (entry.tryLoc <= this.prev) {
-          var hasCatch = hasOwn.call(entry, "catchLoc");
-          var hasFinally = hasOwn.call(entry, "finallyLoc");
-
-          if (hasCatch && hasFinally) {
-            if (this.prev < entry.catchLoc) {
-              return handle(entry.catchLoc, true);
-            } else if (this.prev < entry.finallyLoc) {
-              return handle(entry.finallyLoc);
-            }
-
-          } else if (hasCatch) {
-            if (this.prev < entry.catchLoc) {
-              return handle(entry.catchLoc, true);
-            }
-
-          } else if (hasFinally) {
-            if (this.prev < entry.finallyLoc) {
-              return handle(entry.finallyLoc);
-            }
-
+          attrs._ownerElement = node;
+          return node;
+        },
+        // Introduced in DOM Level 2:
+        createAttributeNS: function(namespaceURI, qualifiedName) {
+          var node = new Attr();
+          var pl = qualifiedName.split(":");
+          node.ownerDocument = this;
+          node.nodeName = qualifiedName;
+          node.name = qualifiedName;
+          node.namespaceURI = namespaceURI;
+          node.specified = true;
+          if (pl.length == 2) {
+            node.prefix = pl[0];
+            node.localName = pl[1];
           } else {
-            throw new Error("try statement without catch or finally");
+            node.localName = qualifiedName;
           }
+          return node;
         }
-      }
-    },
-
-    abrupt: function(type, arg) {
-      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
-        var entry = this.tryEntries[i];
-        if (entry.tryLoc <= this.prev &&
-            hasOwn.call(entry, "finallyLoc") &&
-            this.prev < entry.finallyLoc) {
-          var finallyEntry = entry;
-          break;
-        }
-      }
-
-      if (finallyEntry &&
-          (type === "break" ||
-           type === "continue") &&
-          finallyEntry.tryLoc <= arg &&
-          arg <= finallyEntry.finallyLoc) {
-        // Ignore the finally entry if control is not jumping to a
-        // location outside the try/catch block.
-        finallyEntry = null;
-      }
-
-      var record = finallyEntry ? finallyEntry.completion : {};
-      record.type = type;
-      record.arg = arg;
-
-      if (finallyEntry) {
-        this.next = finallyEntry.finallyLoc;
-      } else {
-        this.complete(record);
-      }
-
-      return ContinueSentinel;
-    },
-
-    complete: function(record, afterLoc) {
-      if (record.type === "throw") {
-        throw record.arg;
-      }
-
-      if (record.type === "break" ||
-          record.type === "continue") {
-        this.next = record.arg;
-      } else if (record.type === "return") {
-        this.rval = record.arg;
-        this.next = "end";
-      } else if (record.type === "normal" && afterLoc) {
-        this.next = afterLoc;
-      }
-    },
-
-    finish: function(finallyLoc) {
-      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
-        var entry = this.tryEntries[i];
-        if (entry.finallyLoc === finallyLoc) {
-          this.complete(entry.completion, entry.afterLoc);
-          resetTryEntry(entry);
-          return ContinueSentinel;
-        }
-      }
-    },
-
-    "catch": function(tryLoc) {
-      for (var i = this.tryEntries.length - 1; i >= 0; --i) {
-        var entry = this.tryEntries[i];
-        if (entry.tryLoc === tryLoc) {
-          var record = entry.completion;
-          if (record.type === "throw") {
-            var thrown = record.arg;
-            resetTryEntry(entry);
-          }
-          return thrown;
-        }
-      }
-
-      // The context.catch method must only be called with a location
-      // argument that corresponds to a known catch block.
-      throw new Error("illegal catch attempt");
-    },
-
-    delegateYield: function(iterable, resultName, nextLoc) {
-      this.delegate = {
-        iterator: values(iterable),
-        resultName: resultName,
-        nextLoc: nextLoc
       };
-
-      return ContinueSentinel;
-    }
-  };
-})(
-  // Among the various tricks for obtaining a reference to the global
-  // object, this seems to be the most reliable technique that does not
-  // use indirect eval (which violates Content Security Policy).
-  typeof global === "object" ? global :
-  typeof window === "object" ? window :
-  typeof self === "object" ? self : this
-);
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.dav = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
-'use strict';
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _co = require('co');
-
-var _co2 = _interopRequireDefault(_co);
-
-var _url = require('url');
-
-var _url2 = _interopRequireDefault(_url);
-
-var _calendars = require('./calendars');
-
-var _contacts = require('./contacts');
-
-var _fuzzy_url_equals = require('./fuzzy_url_equals');
-
-var _fuzzy_url_equals2 = _interopRequireDefault(_fuzzy_url_equals);
-
-var _model = require('./model');
-
-var _namespace = require('./namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-var _request = require('./request');
-
-var request = _interopRequireWildcard(_request);
-
-var debug = require('./debug')('dav:accounts');
-
-var defaults = {
-  accountType: 'caldav',
-  loadCollections: true,
-  loadObjects: false
-};
-
-/**
- * rfc 6764.
- *
- * @param {dav.Account} account to find root url for.
- */
-var serviceDiscovery = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account, options) {
-  var endpoint, uri, req, xhr, _location;
-
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Attempt service discovery.');
-
-        endpoint = _url2['default'].parse(account.server);
-
-        endpoint.protocol = endpoint.protocol || 'http'; // TODO(gareth) https?
-
-        uri = _url2['default'].format({
-          protocol: endpoint.protocol,
-          host: endpoint.host,
-          pathname: !options.useProvidedPath ? '/.well-known/' + options.accountType : endpoint.pathname
+      _extends(Document, Node);
+      function Element() {
+        this._nsMap = {};
+      }
+      Element.prototype = {
+        nodeType: ELEMENT_NODE,
+        hasAttribute: function(name) {
+          return this.getAttributeNode(name) != null;
+        },
+        getAttribute: function(name) {
+          var attr = this.getAttributeNode(name);
+          return attr && attr.value || "";
+        },
+        getAttributeNode: function(name) {
+          return this.attributes.getNamedItem(name);
+        },
+        setAttribute: function(name, value) {
+          var attr = this.ownerDocument.createAttribute(name);
+          attr.value = attr.nodeValue = "" + value;
+          this.setAttributeNode(attr);
+        },
+        removeAttribute: function(name) {
+          var attr = this.getAttributeNode(name);
+          attr && this.removeAttributeNode(attr);
+        },
+        //four real opeartion method
+        appendChild: function(newChild) {
+          if (newChild.nodeType === DOCUMENT_FRAGMENT_NODE) {
+            return this.insertBefore(newChild, null);
+          } else {
+            return _appendSingleChild(this, newChild);
+          }
+        },
+        setAttributeNode: function(newAttr) {
+          return this.attributes.setNamedItem(newAttr);
+        },
+        setAttributeNodeNS: function(newAttr) {
+          return this.attributes.setNamedItemNS(newAttr);
+        },
+        removeAttributeNode: function(oldAttr) {
+          return this.attributes.removeNamedItem(oldAttr.nodeName);
+        },
+        //get real attribute name,and remove it by removeAttributeNode
+        removeAttributeNS: function(namespaceURI, localName) {
+          var old = this.getAttributeNodeNS(namespaceURI, localName);
+          old && this.removeAttributeNode(old);
+        },
+        hasAttributeNS: function(namespaceURI, localName) {
+          return this.getAttributeNodeNS(namespaceURI, localName) != null;
+        },
+        getAttributeNS: function(namespaceURI, localName) {
+          var attr = this.getAttributeNodeNS(namespaceURI, localName);
+          return attr && attr.value || "";
+        },
+        setAttributeNS: function(namespaceURI, qualifiedName, value) {
+          var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);
+          attr.value = attr.nodeValue = "" + value;
+          this.setAttributeNode(attr);
+        },
+        getAttributeNodeNS: function(namespaceURI, localName) {
+          return this.attributes.getNamedItemNS(namespaceURI, localName);
+        },
+        getElementsByTagName: function(tagName) {
+          return new LiveNodeList(this, function(base) {
+            var ls = [];
+            _visitNode(base, function(node) {
+              if (node !== base && node.nodeType == ELEMENT_NODE && (tagName === "*" || node.tagName == tagName)) {
+                ls.push(node);
+              }
+            });
+            return ls;
+          });
+        },
+        getElementsByTagNameNS: function(namespaceURI, localName) {
+          return new LiveNodeList(this, function(base) {
+            var ls = [];
+            _visitNode(base, function(node) {
+              if (node !== base && node.nodeType === ELEMENT_NODE && (namespaceURI === "*" || node.namespaceURI === namespaceURI) && (localName === "*" || node.localName == localName)) {
+                ls.push(node);
+              }
+            });
+            return ls;
+          });
+        }
+      };
+      Document.prototype.getElementsByTagName = Element.prototype.getElementsByTagName;
+      Document.prototype.getElementsByTagNameNS = Element.prototype.getElementsByTagNameNS;
+      _extends(Element, Node);
+      function Attr() {
+      }
+      Attr.prototype.nodeType = ATTRIBUTE_NODE;
+      _extends(Attr, Node);
+      function CharacterData() {
+      }
+      CharacterData.prototype = {
+        data: "",
+        substringData: function(offset, count) {
+          return this.data.substring(offset, offset + count);
+        },
+        appendData: function(text) {
+          text = this.data + text;
+          this.nodeValue = this.data = text;
+          this.length = text.length;
+        },
+        insertData: function(offset, text) {
+          this.replaceData(offset, 0, text);
+        },
+        appendChild: function(newChild) {
+          throw new Error(ExceptionMessage[HIERARCHY_REQUEST_ERR]);
+        },
+        deleteData: function(offset, count) {
+          this.replaceData(offset, count, "");
+        },
+        replaceData: function(offset, count, text) {
+          var start = this.data.substring(0, offset);
+          var end = this.data.substring(offset + count);
+          text = start + text + end;
+          this.nodeValue = this.data = text;
+          this.length = text.length;
+        }
+      };
+      _extends(CharacterData, Node);
+      function Text() {
+      }
+      Text.prototype = {
+        nodeName: "#text",
+        nodeType: TEXT_NODE,
+        splitText: function(offset) {
+          var text = this.data;
+          var newText = text.substring(offset);
+          text = text.substring(0, offset);
+          this.data = this.nodeValue = text;
+          this.length = text.length;
+          var newNode = this.ownerDocument.createTextNode(newText);
+          if (this.parentNode) {
+            this.parentNode.insertBefore(newNode, this.nextSibling);
+          }
+          return newNode;
+        }
+      };
+      _extends(Text, CharacterData);
+      function Comment() {
+      }
+      Comment.prototype = {
+        nodeName: "#comment",
+        nodeType: COMMENT_NODE
+      };
+      _extends(Comment, CharacterData);
+      function CDATASection() {
+      }
+      CDATASection.prototype = {
+        nodeName: "#cdata-section",
+        nodeType: CDATA_SECTION_NODE
+      };
+      _extends(CDATASection, CharacterData);
+      function DocumentType() {
+      }
+      DocumentType.prototype.nodeType = DOCUMENT_TYPE_NODE;
+      _extends(DocumentType, Node);
+      function Notation() {
+      }
+      Notation.prototype.nodeType = NOTATION_NODE;
+      _extends(Notation, Node);
+      function Entity() {
+      }
+      Entity.prototype.nodeType = ENTITY_NODE;
+      _extends(Entity, Node);
+      function EntityReference() {
+      }
+      EntityReference.prototype.nodeType = ENTITY_REFERENCE_NODE;
+      _extends(EntityReference, Node);
+      function DocumentFragment() {
+      }
+      DocumentFragment.prototype.nodeName = "#document-fragment";
+      DocumentFragment.prototype.nodeType = DOCUMENT_FRAGMENT_NODE;
+      _extends(DocumentFragment, Node);
+      function ProcessingInstruction() {
+      }
+      ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
+      _extends(ProcessingInstruction, Node);
+      function XMLSerializer() {
+      }
+      XMLSerializer.prototype.serializeToString = function(node, isHtml, nodeFilter, options) {
+        return nodeSerializeToString.call(node, isHtml, nodeFilter, options);
+      };
+      Node.prototype.toString = nodeSerializeToString;
+      function nodeSerializeToString(isHtml, nodeFilter, options) {
+        var requireWellFormed = !!options && !!options.requireWellFormed;
+        var buf = [];
+        var refNode = this.nodeType == 9 && this.documentElement || this;
+        var prefix = refNode.prefix;
+        var uri = refNode.namespaceURI;
+        if (uri && prefix == null) {
+          var prefix = refNode.lookupPrefix(uri);
+          if (prefix == null) {
+            var visibleNamespaces = [
+              { namespace: uri, prefix: null }
+              //{namespace:uri,prefix:''}
+            ];
+          }
+        }
+        serializeToString(this, buf, isHtml, nodeFilter, visibleNamespaces, requireWellFormed);
+        return buf.join("");
+      }
+      function needNamespaceDefine(node, isHTML, visibleNamespaces) {
+        var prefix = node.prefix || "";
+        var uri = node.namespaceURI;
+        if (!uri) {
+          return false;
+        }
+        if (prefix === "xml" && uri === NAMESPACE.XML || uri === NAMESPACE.XMLNS) {
+          return false;
+        }
+        var i = visibleNamespaces.length;
+        while (i--) {
+          var ns = visibleNamespaces[i];
+          if (ns.prefix === prefix) {
+            return ns.namespace !== uri;
+          }
+        }
+        return true;
+      }
+      function addSerializedAttribute(buf, qualifiedName, value) {
+        buf.push(" ", qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"');
+      }
+      function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, requireWellFormed) {
+        if (!visibleNamespaces) {
+          visibleNamespaces = [];
+        }
+        walkDOM(node, { ns: visibleNamespaces, isHTML }, {
+          enter: function(n, ctx) {
+            var ns = ctx.ns;
+            var html = ctx.isHTML;
+            if (nodeFilter) {
+              n = nodeFilter(n);
+              if (n) {
+                if (typeof n == "string") {
+                  buf.push(n);
+                  return null;
+                }
+              } else {
+                return null;
+              }
+            }
+            switch (n.nodeType) {
+              case ELEMENT_NODE:
+                var attrs = n.attributes;
+                var len = attrs.length;
+                var nodeName = n.tagName;
+                html = NAMESPACE.isHTML(n.namespaceURI) || html;
+                var prefixedNodeName = nodeName;
+                if (!html && !n.prefix && n.namespaceURI) {
+                  var defaultNS;
+                  for (var ai = 0; ai < attrs.length; ai++) {
+                    if (attrs.item(ai).name === "xmlns") {
+                      defaultNS = attrs.item(ai).value;
+                      break;
+                    }
+                  }
+                  if (!defaultNS) {
+                    for (var nsi = ns.length - 1; nsi >= 0; nsi--) {
+                      var nsEntry = ns[nsi];
+                      if (nsEntry.prefix === "" && nsEntry.namespace === n.namespaceURI) {
+                        defaultNS = nsEntry.namespace;
+                        break;
+                      }
+                    }
+                  }
+                  if (defaultNS !== n.namespaceURI) {
+                    for (var nsi = ns.length - 1; nsi >= 0; nsi--) {
+                      var nsEntry = ns[nsi];
+                      if (nsEntry.namespace === n.namespaceURI) {
+                        if (nsEntry.prefix) {
+                          prefixedNodeName = nsEntry.prefix + ":" + nodeName;
+                        }
+                        break;
+                      }
+                    }
+                  }
+                }
+                buf.push("<", prefixedNodeName);
+                var childNs = ns.slice();
+                for (var i = 0; i < len; i++) {
+                  var attr = attrs.item(i);
+                  if (attr.prefix == "xmlns") {
+                    childNs.push({ prefix: attr.localName, namespace: attr.value });
+                  } else if (attr.nodeName == "xmlns") {
+                    childNs.push({ prefix: "", namespace: attr.value });
+                  }
+                }
+                for (var i = 0; i < len; i++) {
+                  var attr = attrs.item(i);
+                  if (needNamespaceDefine(attr, html, childNs)) {
+                    var attrPrefix = attr.prefix || "";
+                    var uri = attr.namespaceURI;
+                    addSerializedAttribute(buf, attrPrefix ? "xmlns:" + attrPrefix : "xmlns", uri);
+                    childNs.push({ prefix: attrPrefix, namespace: uri });
+                  }
+                  var filteredAttr = nodeFilter ? nodeFilter(attr) : attr;
+                  if (filteredAttr) {
+                    if (typeof filteredAttr === "string") {
+                      buf.push(filteredAttr);
+                    } else {
+                      addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value);
+                    }
+                  }
+                }
+                if (nodeName === prefixedNodeName && needNamespaceDefine(n, html, childNs)) {
+                  var nodePrefix = n.prefix || "";
+                  var uri = n.namespaceURI;
+                  addSerializedAttribute(buf, nodePrefix ? "xmlns:" + nodePrefix : "xmlns", uri);
+                  childNs.push({ prefix: nodePrefix, namespace: uri });
+                }
+                var child2 = n.firstChild;
+                if (child2 || html && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)) {
+                  buf.push(">");
+                  if (html && /^script$/i.test(nodeName)) {
+                    while (child2) {
+                      if (child2.data) {
+                        buf.push(child2.data);
+                      } else {
+                        serializeToString(child2, buf, html, nodeFilter, childNs.slice(), requireWellFormed);
+                      }
+                      child2 = child2.nextSibling;
+                    }
+                    buf.push("</", nodeName, ">");
+                    return null;
+                  }
+                  return { ns: childNs, isHTML: html, tag: prefixedNodeName };
+                } else {
+                  buf.push("/>");
+                  return null;
+                }
+              case DOCUMENT_NODE:
+              case DOCUMENT_FRAGMENT_NODE:
+                return { ns: ns.slice(), isHTML: html, tag: null };
+              case ATTRIBUTE_NODE:
+                addSerializedAttribute(buf, n.name, n.value);
+                return null;
+              case TEXT_NODE:
+                buf.push(n.data.replace(/[<&>]/g, _xmlEncoder));
+                return null;
+              case CDATA_SECTION_NODE:
+                if (requireWellFormed && n.data.indexOf("]]>") !== -1) {
+                  throw new DOMException(INVALID_STATE_ERR, 'The CDATASection data contains "]]>"');
+                }
+                buf.push("<![CDATA[", n.data.replace(/]]>/g, "]]]]><![CDATA[>"), "]]>");
+                return null;
+              case COMMENT_NODE:
+                if (requireWellFormed && n.data.indexOf("-->") !== -1) {
+                  throw new DOMException(INVALID_STATE_ERR, 'The comment node data contains "-->"');
+                }
+                buf.push("<!--", n.data, "-->");
+                return null;
+              case DOCUMENT_TYPE_NODE:
+                if (requireWellFormed) {
+                  if (n.publicId && !/^("[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%']*"|'[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%'"]*')$/.test(n.publicId)) {
+                    throw new DOMException(INVALID_STATE_ERR, "DocumentType publicId is not a valid PubidLiteral");
+                  }
+                  if (n.systemId && !/^("[^"]*"|'[^']*')$/.test(n.systemId)) {
+                    throw new DOMException(INVALID_STATE_ERR, "DocumentType systemId is not a valid SystemLiteral");
+                  }
+                  if (n.internalSubset && n.internalSubset.indexOf("]>") !== -1) {
+                    throw new DOMException(INVALID_STATE_ERR, 'DocumentType internalSubset contains "]>"');
+                  }
+                }
+                var pubid = n.publicId;
+                var sysid = n.systemId;
+                buf.push("<!DOCTYPE ", n.name);
+                if (pubid) {
+                  buf.push(" PUBLIC ", pubid);
+                  if (sysid && sysid != ".") {
+                    buf.push(" ", sysid);
+                  }
+                  buf.push(">");
+                } else if (sysid && sysid != ".") {
+                  buf.push(" SYSTEM ", sysid, ">");
+                } else {
+                  var sub = n.internalSubset;
+                  if (sub) {
+                    buf.push(" [", sub, "]");
+                  }
+                  buf.push(">");
+                }
+                return null;
+              case PROCESSING_INSTRUCTION_NODE:
+                if (requireWellFormed && n.data.indexOf("?>") !== -1) {
+                  throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
+                }
+                buf.push("<?", n.target, " ", n.data, "?>");
+                return null;
+              case ENTITY_REFERENCE_NODE:
+                buf.push("&", n.nodeName, ";");
+                return null;
+              //case ENTITY_NODE:
+              //case NOTATION_NODE:
+              default:
+                buf.push("??", n.nodeName);
+                return null;
+            }
+          },
+          exit: function(n, childCtx) {
+            if (childCtx && childCtx.tag) {
+              buf.push("</", childCtx.tag, ">");
+            }
+          }
         });
-        req = request.basic({ method: 'GET' });
-        context$1$0.prev = 5;
-        context$1$0.next = 8;
-        return options.xhr.send(req, uri, { sandbox: options.sandbox });
-
-      case 8:
-        xhr = context$1$0.sent;
-
-        if (!(xhr.status >= 300 && xhr.status < 400)) {
-          context$1$0.next = 14;
-          break;
+      }
+      function importNode(doc, node, deep) {
+        var destRoot;
+        walkDOM(node, null, {
+          enter: function(srcNode, destParent) {
+            var destNode = srcNode.cloneNode(false);
+            destNode.ownerDocument = doc;
+            destNode.parentNode = null;
+            if (destParent === null) {
+              destRoot = destNode;
+            } else {
+              destParent.appendChild(destNode);
+            }
+            var shouldDeep = srcNode.nodeType === ATTRIBUTE_NODE || deep;
+            return shouldDeep ? destNode : null;
+          }
+        });
+        return destRoot;
+      }
+      function cloneNode(doc, node, deep) {
+        var destRoot;
+        walkDOM(node, null, {
+          enter: function(srcNode, destParent) {
+            var destNode = new srcNode.constructor();
+            for (var n in srcNode) {
+              if (Object.prototype.hasOwnProperty.call(srcNode, n)) {
+                var v = srcNode[n];
+                if (typeof v != "object") {
+                  if (v != destNode[n]) {
+                    destNode[n] = v;
+                  }
+                }
+              }
+            }
+            if (srcNode.childNodes) {
+              destNode.childNodes = new NodeList();
+            }
+            destNode.ownerDocument = doc;
+            var shouldDeep = deep;
+            switch (destNode.nodeType) {
+              case ELEMENT_NODE:
+                var attrs = srcNode.attributes;
+                var attrs2 = destNode.attributes = new NamedNodeMap();
+                var len = attrs.length;
+                attrs2._ownerElement = destNode;
+                for (var i = 0; i < len; i++) {
+                  destNode.setAttributeNode(cloneNode(doc, attrs.item(i), true));
+                }
+                break;
+              case ATTRIBUTE_NODE:
+                shouldDeep = true;
+            }
+            if (destParent !== null) {
+              destParent.appendChild(destNode);
+            } else {
+              destRoot = destNode;
+            }
+            return shouldDeep ? destNode : null;
+          }
+        });
+        return destRoot;
+      }
+      function __set__(object, key, value) {
+        object[key] = value;
+      }
+      try {
+        if (Object.defineProperty) {
+          Object.defineProperty(LiveNodeList.prototype, "length", {
+            get: function() {
+              _updateLiveList(this);
+              return this.$$length;
+            }
+          });
+          Object.defineProperty(Node.prototype, "textContent", {
+            get: function() {
+              if (this.nodeType === ELEMENT_NODE || this.nodeType === DOCUMENT_FRAGMENT_NODE) {
+                var buf = [];
+                walkDOM(this, null, {
+                  enter: function(n) {
+                    if (n.nodeType === ELEMENT_NODE || n.nodeType === DOCUMENT_FRAGMENT_NODE) {
+                      return true;
+                    }
+                    if (n.nodeType === PROCESSING_INSTRUCTION_NODE || n.nodeType === COMMENT_NODE) {
+                      return null;
+                    }
+                    buf.push(n.nodeValue);
+                  }
+                });
+                return buf.join("");
+              }
+              return this.nodeValue;
+            },
+            set: function(data) {
+              switch (this.nodeType) {
+                case ELEMENT_NODE:
+                case DOCUMENT_FRAGMENT_NODE:
+                  while (this.firstChild) {
+                    this.removeChild(this.firstChild);
+                  }
+                  if (data || String(data)) {
+                    this.appendChild(this.ownerDocument.createTextNode(data));
+                  }
+                  break;
+                default:
+                  this.data = data;
+                  this.value = data;
+                  this.nodeValue = data;
+              }
+            }
+          });
+          __set__ = function(object, key, value) {
+            object["$$" + key] = value;
+          };
         }
-
-        _location = xhr.getResponseHeader('Location');
-
-        if (!(typeof _location === 'string' && _location.length)) {
-          context$1$0.next = 14;
-          break;
-        }
-
-        debug('Discovery redirected to ' + _location);
-        return context$1$0.abrupt('return', _url2['default'].format({
-          protocol: endpoint.protocol,
-          host: endpoint.host,
-          pathname: _location
-        }));
-
-      case 14:
-        context$1$0.next = 19;
-        break;
-
-      case 16:
-        context$1$0.prev = 16;
-        context$1$0.t0 = context$1$0['catch'](5);
-
-        debug('Discovery failed... failover to the provided url');
-
-      case 19:
-        return context$1$0.abrupt('return', endpoint.href);
-
-      case 20:
-      case 'end':
-        return context$1$0.stop();
+      } catch (e) {
+      }
+      exports.DocumentType = DocumentType;
+      exports.DOMException = DOMException;
+      exports.DOMImplementation = DOMImplementation;
+      exports.Element = Element;
+      exports.Node = Node;
+      exports.NodeList = NodeList;
+      exports.walkDOM = walkDOM;
+      exports.XMLSerializer = XMLSerializer;
     }
-  }, callee$0$0, this, [[5, 16]]);
-}));
+  });
 
-/**
- * rfc 5397.
- *
- * @param {dav.Account} account to get principal url for.
- */
-var principalUrl = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account, options) {
-  var req, res, container;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Fetch principal url from context path ' + account.rootUrl + '.');
-        req = request.propfind({
-          props: [{ name: 'current-user-principal', namespace: ns.DAV }],
-          depth: 0,
+  // node_modules/@xmldom/xmldom/lib/entities.js
+  var require_entities = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/entities.js"(exports) {
+      "use strict";
+      var freeze = require_conventions().freeze;
+      exports.XML_ENTITIES = freeze({
+        amp: "&",
+        apos: "'",
+        gt: ">",
+        lt: "<",
+        quot: '"'
+      });
+      exports.HTML_ENTITIES = freeze({
+        Aacute: "\xC1",
+        aacute: "\xE1",
+        Abreve: "\u0102",
+        abreve: "\u0103",
+        ac: "\u223E",
+        acd: "\u223F",
+        acE: "\u223E\u0333",
+        Acirc: "\xC2",
+        acirc: "\xE2",
+        acute: "\xB4",
+        Acy: "\u0410",
+        acy: "\u0430",
+        AElig: "\xC6",
+        aelig: "\xE6",
+        af: "\u2061",
+        Afr: "\u{1D504}",
+        afr: "\u{1D51E}",
+        Agrave: "\xC0",
+        agrave: "\xE0",
+        alefsym: "\u2135",
+        aleph: "\u2135",
+        Alpha: "\u0391",
+        alpha: "\u03B1",
+        Amacr: "\u0100",
+        amacr: "\u0101",
+        amalg: "\u2A3F",
+        AMP: "&",
+        amp: "&",
+        And: "\u2A53",
+        and: "\u2227",
+        andand: "\u2A55",
+        andd: "\u2A5C",
+        andslope: "\u2A58",
+        andv: "\u2A5A",
+        ang: "\u2220",
+        ange: "\u29A4",
+        angle: "\u2220",
+        angmsd: "\u2221",
+        angmsdaa: "\u29A8",
+        angmsdab: "\u29A9",
+        angmsdac: "\u29AA",
+        angmsdad: "\u29AB",
+        angmsdae: "\u29AC",
+        angmsdaf: "\u29AD",
+        angmsdag: "\u29AE",
+        angmsdah: "\u29AF",
+        angrt: "\u221F",
+        angrtvb: "\u22BE",
+        angrtvbd: "\u299D",
+        angsph: "\u2222",
+        angst: "\xC5",
+        angzarr: "\u237C",
+        Aogon: "\u0104",
+        aogon: "\u0105",
+        Aopf: "\u{1D538}",
+        aopf: "\u{1D552}",
+        ap: "\u2248",
+        apacir: "\u2A6F",
+        apE: "\u2A70",
+        ape: "\u224A",
+        apid: "\u224B",
+        apos: "'",
+        ApplyFunction: "\u2061",
+        approx: "\u2248",
+        approxeq: "\u224A",
+        Aring: "\xC5",
+        aring: "\xE5",
+        Ascr: "\u{1D49C}",
+        ascr: "\u{1D4B6}",
+        Assign: "\u2254",
+        ast: "*",
+        asymp: "\u2248",
+        asympeq: "\u224D",
+        Atilde: "\xC3",
+        atilde: "\xE3",
+        Auml: "\xC4",
+        auml: "\xE4",
+        awconint: "\u2233",
+        awint: "\u2A11",
+        backcong: "\u224C",
+        backepsilon: "\u03F6",
+        backprime: "\u2035",
+        backsim: "\u223D",
+        backsimeq: "\u22CD",
+        Backslash: "\u2216",
+        Barv: "\u2AE7",
+        barvee: "\u22BD",
+        Barwed: "\u2306",
+        barwed: "\u2305",
+        barwedge: "\u2305",
+        bbrk: "\u23B5",
+        bbrktbrk: "\u23B6",
+        bcong: "\u224C",
+        Bcy: "\u0411",
+        bcy: "\u0431",
+        bdquo: "\u201E",
+        becaus: "\u2235",
+        Because: "\u2235",
+        because: "\u2235",
+        bemptyv: "\u29B0",
+        bepsi: "\u03F6",
+        bernou: "\u212C",
+        Bernoullis: "\u212C",
+        Beta: "\u0392",
+        beta: "\u03B2",
+        beth: "\u2136",
+        between: "\u226C",
+        Bfr: "\u{1D505}",
+        bfr: "\u{1D51F}",
+        bigcap: "\u22C2",
+        bigcirc: "\u25EF",
+        bigcup: "\u22C3",
+        bigodot: "\u2A00",
+        bigoplus: "\u2A01",
+        bigotimes: "\u2A02",
+        bigsqcup: "\u2A06",
+        bigstar: "\u2605",
+        bigtriangledown: "\u25BD",
+        bigtriangleup: "\u25B3",
+        biguplus: "\u2A04",
+        bigvee: "\u22C1",
+        bigwedge: "\u22C0",
+        bkarow: "\u290D",
+        blacklozenge: "\u29EB",
+        blacksquare: "\u25AA",
+        blacktriangle: "\u25B4",
+        blacktriangledown: "\u25BE",
+        blacktriangleleft: "\u25C2",
+        blacktriangleright: "\u25B8",
+        blank: "\u2423",
+        blk12: "\u2592",
+        blk14: "\u2591",
+        blk34: "\u2593",
+        block: "\u2588",
+        bne: "=\u20E5",
+        bnequiv: "\u2261\u20E5",
+        bNot: "\u2AED",
+        bnot: "\u2310",
+        Bopf: "\u{1D539}",
+        bopf: "\u{1D553}",
+        bot: "\u22A5",
+        bottom: "\u22A5",
+        bowtie: "\u22C8",
+        boxbox: "\u29C9",
+        boxDL: "\u2557",
+        boxDl: "\u2556",
+        boxdL: "\u2555",
+        boxdl: "\u2510",
+        boxDR: "\u2554",
+        boxDr: "\u2553",
+        boxdR: "\u2552",
+        boxdr: "\u250C",
+        boxH: "\u2550",
+        boxh: "\u2500",
+        boxHD: "\u2566",
+        boxHd: "\u2564",
+        boxhD: "\u2565",
+        boxhd: "\u252C",
+        boxHU: "\u2569",
+        boxHu: "\u2567",
+        boxhU: "\u2568",
+        boxhu: "\u2534",
+        boxminus: "\u229F",
+        boxplus: "\u229E",
+        boxtimes: "\u22A0",
+        boxUL: "\u255D",
+        boxUl: "\u255C",
+        boxuL: "\u255B",
+        boxul: "\u2518",
+        boxUR: "\u255A",
+        boxUr: "\u2559",
+        boxuR: "\u2558",
+        boxur: "\u2514",
+        boxV: "\u2551",
+        boxv: "\u2502",
+        boxVH: "\u256C",
+        boxVh: "\u256B",
+        boxvH: "\u256A",
+        boxvh: "\u253C",
+        boxVL: "\u2563",
+        boxVl: "\u2562",
+        boxvL: "\u2561",
+        boxvl: "\u2524",
+        boxVR: "\u2560",
+        boxVr: "\u255F",
+        boxvR: "\u255E",
+        boxvr: "\u251C",
+        bprime: "\u2035",
+        Breve: "\u02D8",
+        breve: "\u02D8",
+        brvbar: "\xA6",
+        Bscr: "\u212C",
+        bscr: "\u{1D4B7}",
+        bsemi: "\u204F",
+        bsim: "\u223D",
+        bsime: "\u22CD",
+        bsol: "\\",
+        bsolb: "\u29C5",
+        bsolhsub: "\u27C8",
+        bull: "\u2022",
+        bullet: "\u2022",
+        bump: "\u224E",
+        bumpE: "\u2AAE",
+        bumpe: "\u224F",
+        Bumpeq: "\u224E",
+        bumpeq: "\u224F",
+        Cacute: "\u0106",
+        cacute: "\u0107",
+        Cap: "\u22D2",
+        cap: "\u2229",
+        capand: "\u2A44",
+        capbrcup: "\u2A49",
+        capcap: "\u2A4B",
+        capcup: "\u2A47",
+        capdot: "\u2A40",
+        CapitalDifferentialD: "\u2145",
+        caps: "\u2229\uFE00",
+        caret: "\u2041",
+        caron: "\u02C7",
+        Cayleys: "\u212D",
+        ccaps: "\u2A4D",
+        Ccaron: "\u010C",
+        ccaron: "\u010D",
+        Ccedil: "\xC7",
+        ccedil: "\xE7",
+        Ccirc: "\u0108",
+        ccirc: "\u0109",
+        Cconint: "\u2230",
+        ccups: "\u2A4C",
+        ccupssm: "\u2A50",
+        Cdot: "\u010A",
+        cdot: "\u010B",
+        cedil: "\xB8",
+        Cedilla: "\xB8",
+        cemptyv: "\u29B2",
+        cent: "\xA2",
+        CenterDot: "\xB7",
+        centerdot: "\xB7",
+        Cfr: "\u212D",
+        cfr: "\u{1D520}",
+        CHcy: "\u0427",
+        chcy: "\u0447",
+        check: "\u2713",
+        checkmark: "\u2713",
+        Chi: "\u03A7",
+        chi: "\u03C7",
+        cir: "\u25CB",
+        circ: "\u02C6",
+        circeq: "\u2257",
+        circlearrowleft: "\u21BA",
+        circlearrowright: "\u21BB",
+        circledast: "\u229B",
+        circledcirc: "\u229A",
+        circleddash: "\u229D",
+        CircleDot: "\u2299",
+        circledR: "\xAE",
+        circledS: "\u24C8",
+        CircleMinus: "\u2296",
+        CirclePlus: "\u2295",
+        CircleTimes: "\u2297",
+        cirE: "\u29C3",
+        cire: "\u2257",
+        cirfnint: "\u2A10",
+        cirmid: "\u2AEF",
+        cirscir: "\u29C2",
+        ClockwiseContourIntegral: "\u2232",
+        CloseCurlyDoubleQuote: "\u201D",
+        CloseCurlyQuote: "\u2019",
+        clubs: "\u2663",
+        clubsuit: "\u2663",
+        Colon: "\u2237",
+        colon: ":",
+        Colone: "\u2A74",
+        colone: "\u2254",
+        coloneq: "\u2254",
+        comma: ",",
+        commat: "@",
+        comp: "\u2201",
+        compfn: "\u2218",
+        complement: "\u2201",
+        complexes: "\u2102",
+        cong: "\u2245",
+        congdot: "\u2A6D",
+        Congruent: "\u2261",
+        Conint: "\u222F",
+        conint: "\u222E",
+        ContourIntegral: "\u222E",
+        Copf: "\u2102",
+        copf: "\u{1D554}",
+        coprod: "\u2210",
+        Coproduct: "\u2210",
+        COPY: "\xA9",
+        copy: "\xA9",
+        copysr: "\u2117",
+        CounterClockwiseContourIntegral: "\u2233",
+        crarr: "\u21B5",
+        Cross: "\u2A2F",
+        cross: "\u2717",
+        Cscr: "\u{1D49E}",
+        cscr: "\u{1D4B8}",
+        csub: "\u2ACF",
+        csube: "\u2AD1",
+        csup: "\u2AD0",
+        csupe: "\u2AD2",
+        ctdot: "\u22EF",
+        cudarrl: "\u2938",
+        cudarrr: "\u2935",
+        cuepr: "\u22DE",
+        cuesc: "\u22DF",
+        cularr: "\u21B6",
+        cularrp: "\u293D",
+        Cup: "\u22D3",
+        cup: "\u222A",
+        cupbrcap: "\u2A48",
+        CupCap: "\u224D",
+        cupcap: "\u2A46",
+        cupcup: "\u2A4A",
+        cupdot: "\u228D",
+        cupor: "\u2A45",
+        cups: "\u222A\uFE00",
+        curarr: "\u21B7",
+        curarrm: "\u293C",
+        curlyeqprec: "\u22DE",
+        curlyeqsucc: "\u22DF",
+        curlyvee: "\u22CE",
+        curlywedge: "\u22CF",
+        curren: "\xA4",
+        curvearrowleft: "\u21B6",
+        curvearrowright: "\u21B7",
+        cuvee: "\u22CE",
+        cuwed: "\u22CF",
+        cwconint: "\u2232",
+        cwint: "\u2231",
+        cylcty: "\u232D",
+        Dagger: "\u2021",
+        dagger: "\u2020",
+        daleth: "\u2138",
+        Darr: "\u21A1",
+        dArr: "\u21D3",
+        darr: "\u2193",
+        dash: "\u2010",
+        Dashv: "\u2AE4",
+        dashv: "\u22A3",
+        dbkarow: "\u290F",
+        dblac: "\u02DD",
+        Dcaron: "\u010E",
+        dcaron: "\u010F",
+        Dcy: "\u0414",
+        dcy: "\u0434",
+        DD: "\u2145",
+        dd: "\u2146",
+        ddagger: "\u2021",
+        ddarr: "\u21CA",
+        DDotrahd: "\u2911",
+        ddotseq: "\u2A77",
+        deg: "\xB0",
+        Del: "\u2207",
+        Delta: "\u0394",
+        delta: "\u03B4",
+        demptyv: "\u29B1",
+        dfisht: "\u297F",
+        Dfr: "\u{1D507}",
+        dfr: "\u{1D521}",
+        dHar: "\u2965",
+        dharl: "\u21C3",
+        dharr: "\u21C2",
+        DiacriticalAcute: "\xB4",
+        DiacriticalDot: "\u02D9",
+        DiacriticalDoubleAcute: "\u02DD",
+        DiacriticalGrave: "`",
+        DiacriticalTilde: "\u02DC",
+        diam: "\u22C4",
+        Diamond: "\u22C4",
+        diamond: "\u22C4",
+        diamondsuit: "\u2666",
+        diams: "\u2666",
+        die: "\xA8",
+        DifferentialD: "\u2146",
+        digamma: "\u03DD",
+        disin: "\u22F2",
+        div: "\xF7",
+        divide: "\xF7",
+        divideontimes: "\u22C7",
+        divonx: "\u22C7",
+        DJcy: "\u0402",
+        djcy: "\u0452",
+        dlcorn: "\u231E",
+        dlcrop: "\u230D",
+        dollar: "$",
+        Dopf: "\u{1D53B}",
+        dopf: "\u{1D555}",
+        Dot: "\xA8",
+        dot: "\u02D9",
+        DotDot: "\u20DC",
+        doteq: "\u2250",
+        doteqdot: "\u2251",
+        DotEqual: "\u2250",
+        dotminus: "\u2238",
+        dotplus: "\u2214",
+        dotsquare: "\u22A1",
+        doublebarwedge: "\u2306",
+        DoubleContourIntegral: "\u222F",
+        DoubleDot: "\xA8",
+        DoubleDownArrow: "\u21D3",
+        DoubleLeftArrow: "\u21D0",
+        DoubleLeftRightArrow: "\u21D4",
+        DoubleLeftTee: "\u2AE4",
+        DoubleLongLeftArrow: "\u27F8",
+        DoubleLongLeftRightArrow: "\u27FA",
+        DoubleLongRightArrow: "\u27F9",
+        DoubleRightArrow: "\u21D2",
+        DoubleRightTee: "\u22A8",
+        DoubleUpArrow: "\u21D1",
+        DoubleUpDownArrow: "\u21D5",
+        DoubleVerticalBar: "\u2225",
+        DownArrow: "\u2193",
+        Downarrow: "\u21D3",
+        downarrow: "\u2193",
+        DownArrowBar: "\u2913",
+        DownArrowUpArrow: "\u21F5",
+        DownBreve: "\u0311",
+        downdownarrows: "\u21CA",
+        downharpoonleft: "\u21C3",
+        downharpoonright: "\u21C2",
+        DownLeftRightVector: "\u2950",
+        DownLeftTeeVector: "\u295E",
+        DownLeftVector: "\u21BD",
+        DownLeftVectorBar: "\u2956",
+        DownRightTeeVector: "\u295F",
+        DownRightVector: "\u21C1",
+        DownRightVectorBar: "\u2957",
+        DownTee: "\u22A4",
+        DownTeeArrow: "\u21A7",
+        drbkarow: "\u2910",
+        drcorn: "\u231F",
+        drcrop: "\u230C",
+        Dscr: "\u{1D49F}",
+        dscr: "\u{1D4B9}",
+        DScy: "\u0405",
+        dscy: "\u0455",
+        dsol: "\u29F6",
+        Dstrok: "\u0110",
+        dstrok: "\u0111",
+        dtdot: "\u22F1",
+        dtri: "\u25BF",
+        dtrif: "\u25BE",
+        duarr: "\u21F5",
+        duhar: "\u296F",
+        dwangle: "\u29A6",
+        DZcy: "\u040F",
+        dzcy: "\u045F",
+        dzigrarr: "\u27FF",
+        Eacute: "\xC9",
+        eacute: "\xE9",
+        easter: "\u2A6E",
+        Ecaron: "\u011A",
+        ecaron: "\u011B",
+        ecir: "\u2256",
+        Ecirc: "\xCA",
+        ecirc: "\xEA",
+        ecolon: "\u2255",
+        Ecy: "\u042D",
+        ecy: "\u044D",
+        eDDot: "\u2A77",
+        Edot: "\u0116",
+        eDot: "\u2251",
+        edot: "\u0117",
+        ee: "\u2147",
+        efDot: "\u2252",
+        Efr: "\u{1D508}",
+        efr: "\u{1D522}",
+        eg: "\u2A9A",
+        Egrave: "\xC8",
+        egrave: "\xE8",
+        egs: "\u2A96",
+        egsdot: "\u2A98",
+        el: "\u2A99",
+        Element: "\u2208",
+        elinters: "\u23E7",
+        ell: "\u2113",
+        els: "\u2A95",
+        elsdot: "\u2A97",
+        Emacr: "\u0112",
+        emacr: "\u0113",
+        empty: "\u2205",
+        emptyset: "\u2205",
+        EmptySmallSquare: "\u25FB",
+        emptyv: "\u2205",
+        EmptyVerySmallSquare: "\u25AB",
+        emsp: "\u2003",
+        emsp13: "\u2004",
+        emsp14: "\u2005",
+        ENG: "\u014A",
+        eng: "\u014B",
+        ensp: "\u2002",
+        Eogon: "\u0118",
+        eogon: "\u0119",
+        Eopf: "\u{1D53C}",
+        eopf: "\u{1D556}",
+        epar: "\u22D5",
+        eparsl: "\u29E3",
+        eplus: "\u2A71",
+        epsi: "\u03B5",
+        Epsilon: "\u0395",
+        epsilon: "\u03B5",
+        epsiv: "\u03F5",
+        eqcirc: "\u2256",
+        eqcolon: "\u2255",
+        eqsim: "\u2242",
+        eqslantgtr: "\u2A96",
+        eqslantless: "\u2A95",
+        Equal: "\u2A75",
+        equals: "=",
+        EqualTilde: "\u2242",
+        equest: "\u225F",
+        Equilibrium: "\u21CC",
+        equiv: "\u2261",
+        equivDD: "\u2A78",
+        eqvparsl: "\u29E5",
+        erarr: "\u2971",
+        erDot: "\u2253",
+        Escr: "\u2130",
+        escr: "\u212F",
+        esdot: "\u2250",
+        Esim: "\u2A73",
+        esim: "\u2242",
+        Eta: "\u0397",
+        eta: "\u03B7",
+        ETH: "\xD0",
+        eth: "\xF0",
+        Euml: "\xCB",
+        euml: "\xEB",
+        euro: "\u20AC",
+        excl: "!",
+        exist: "\u2203",
+        Exists: "\u2203",
+        expectation: "\u2130",
+        ExponentialE: "\u2147",
+        exponentiale: "\u2147",
+        fallingdotseq: "\u2252",
+        Fcy: "\u0424",
+        fcy: "\u0444",
+        female: "\u2640",
+        ffilig: "\uFB03",
+        fflig: "\uFB00",
+        ffllig: "\uFB04",
+        Ffr: "\u{1D509}",
+        ffr: "\u{1D523}",
+        filig: "\uFB01",
+        FilledSmallSquare: "\u25FC",
+        FilledVerySmallSquare: "\u25AA",
+        fjlig: "fj",
+        flat: "\u266D",
+        fllig: "\uFB02",
+        fltns: "\u25B1",
+        fnof: "\u0192",
+        Fopf: "\u{1D53D}",
+        fopf: "\u{1D557}",
+        ForAll: "\u2200",
+        forall: "\u2200",
+        fork: "\u22D4",
+        forkv: "\u2AD9",
+        Fouriertrf: "\u2131",
+        fpartint: "\u2A0D",
+        frac12: "\xBD",
+        frac13: "\u2153",
+        frac14: "\xBC",
+        frac15: "\u2155",
+        frac16: "\u2159",
+        frac18: "\u215B",
+        frac23: "\u2154",
+        frac25: "\u2156",
+        frac34: "\xBE",
+        frac35: "\u2157",
+        frac38: "\u215C",
+        frac45: "\u2158",
+        frac56: "\u215A",
+        frac58: "\u215D",
+        frac78: "\u215E",
+        frasl: "\u2044",
+        frown: "\u2322",
+        Fscr: "\u2131",
+        fscr: "\u{1D4BB}",
+        gacute: "\u01F5",
+        Gamma: "\u0393",
+        gamma: "\u03B3",
+        Gammad: "\u03DC",
+        gammad: "\u03DD",
+        gap: "\u2A86",
+        Gbreve: "\u011E",
+        gbreve: "\u011F",
+        Gcedil: "\u0122",
+        Gcirc: "\u011C",
+        gcirc: "\u011D",
+        Gcy: "\u0413",
+        gcy: "\u0433",
+        Gdot: "\u0120",
+        gdot: "\u0121",
+        gE: "\u2267",
+        ge: "\u2265",
+        gEl: "\u2A8C",
+        gel: "\u22DB",
+        geq: "\u2265",
+        geqq: "\u2267",
+        geqslant: "\u2A7E",
+        ges: "\u2A7E",
+        gescc: "\u2AA9",
+        gesdot: "\u2A80",
+        gesdoto: "\u2A82",
+        gesdotol: "\u2A84",
+        gesl: "\u22DB\uFE00",
+        gesles: "\u2A94",
+        Gfr: "\u{1D50A}",
+        gfr: "\u{1D524}",
+        Gg: "\u22D9",
+        gg: "\u226B",
+        ggg: "\u22D9",
+        gimel: "\u2137",
+        GJcy: "\u0403",
+        gjcy: "\u0453",
+        gl: "\u2277",
+        gla: "\u2AA5",
+        glE: "\u2A92",
+        glj: "\u2AA4",
+        gnap: "\u2A8A",
+        gnapprox: "\u2A8A",
+        gnE: "\u2269",
+        gne: "\u2A88",
+        gneq: "\u2A88",
+        gneqq: "\u2269",
+        gnsim: "\u22E7",
+        Gopf: "\u{1D53E}",
+        gopf: "\u{1D558}",
+        grave: "`",
+        GreaterEqual: "\u2265",
+        GreaterEqualLess: "\u22DB",
+        GreaterFullEqual: "\u2267",
+        GreaterGreater: "\u2AA2",
+        GreaterLess: "\u2277",
+        GreaterSlantEqual: "\u2A7E",
+        GreaterTilde: "\u2273",
+        Gscr: "\u{1D4A2}",
+        gscr: "\u210A",
+        gsim: "\u2273",
+        gsime: "\u2A8E",
+        gsiml: "\u2A90",
+        Gt: "\u226B",
+        GT: ">",
+        gt: ">",
+        gtcc: "\u2AA7",
+        gtcir: "\u2A7A",
+        gtdot: "\u22D7",
+        gtlPar: "\u2995",
+        gtquest: "\u2A7C",
+        gtrapprox: "\u2A86",
+        gtrarr: "\u2978",
+        gtrdot: "\u22D7",
+        gtreqless: "\u22DB",
+        gtreqqless: "\u2A8C",
+        gtrless: "\u2277",
+        gtrsim: "\u2273",
+        gvertneqq: "\u2269\uFE00",
+        gvnE: "\u2269\uFE00",
+        Hacek: "\u02C7",
+        hairsp: "\u200A",
+        half: "\xBD",
+        hamilt: "\u210B",
+        HARDcy: "\u042A",
+        hardcy: "\u044A",
+        hArr: "\u21D4",
+        harr: "\u2194",
+        harrcir: "\u2948",
+        harrw: "\u21AD",
+        Hat: "^",
+        hbar: "\u210F",
+        Hcirc: "\u0124",
+        hcirc: "\u0125",
+        hearts: "\u2665",
+        heartsuit: "\u2665",
+        hellip: "\u2026",
+        hercon: "\u22B9",
+        Hfr: "\u210C",
+        hfr: "\u{1D525}",
+        HilbertSpace: "\u210B",
+        hksearow: "\u2925",
+        hkswarow: "\u2926",
+        hoarr: "\u21FF",
+        homtht: "\u223B",
+        hookleftarrow: "\u21A9",
+        hookrightarrow: "\u21AA",
+        Hopf: "\u210D",
+        hopf: "\u{1D559}",
+        horbar: "\u2015",
+        HorizontalLine: "\u2500",
+        Hscr: "\u210B",
+        hscr: "\u{1D4BD}",
+        hslash: "\u210F",
+        Hstrok: "\u0126",
+        hstrok: "\u0127",
+        HumpDownHump: "\u224E",
+        HumpEqual: "\u224F",
+        hybull: "\u2043",
+        hyphen: "\u2010",
+        Iacute: "\xCD",
+        iacute: "\xED",
+        ic: "\u2063",
+        Icirc: "\xCE",
+        icirc: "\xEE",
+        Icy: "\u0418",
+        icy: "\u0438",
+        Idot: "\u0130",
+        IEcy: "\u0415",
+        iecy: "\u0435",
+        iexcl: "\xA1",
+        iff: "\u21D4",
+        Ifr: "\u2111",
+        ifr: "\u{1D526}",
+        Igrave: "\xCC",
+        igrave: "\xEC",
+        ii: "\u2148",
+        iiiint: "\u2A0C",
+        iiint: "\u222D",
+        iinfin: "\u29DC",
+        iiota: "\u2129",
+        IJlig: "\u0132",
+        ijlig: "\u0133",
+        Im: "\u2111",
+        Imacr: "\u012A",
+        imacr: "\u012B",
+        image: "\u2111",
+        ImaginaryI: "\u2148",
+        imagline: "\u2110",
+        imagpart: "\u2111",
+        imath: "\u0131",
+        imof: "\u22B7",
+        imped: "\u01B5",
+        Implies: "\u21D2",
+        in: "\u2208",
+        incare: "\u2105",
+        infin: "\u221E",
+        infintie: "\u29DD",
+        inodot: "\u0131",
+        Int: "\u222C",
+        int: "\u222B",
+        intcal: "\u22BA",
+        integers: "\u2124",
+        Integral: "\u222B",
+        intercal: "\u22BA",
+        Intersection: "\u22C2",
+        intlarhk: "\u2A17",
+        intprod: "\u2A3C",
+        InvisibleComma: "\u2063",
+        InvisibleTimes: "\u2062",
+        IOcy: "\u0401",
+        iocy: "\u0451",
+        Iogon: "\u012E",
+        iogon: "\u012F",
+        Iopf: "\u{1D540}",
+        iopf: "\u{1D55A}",
+        Iota: "\u0399",
+        iota: "\u03B9",
+        iprod: "\u2A3C",
+        iquest: "\xBF",
+        Iscr: "\u2110",
+        iscr: "\u{1D4BE}",
+        isin: "\u2208",
+        isindot: "\u22F5",
+        isinE: "\u22F9",
+        isins: "\u22F4",
+        isinsv: "\u22F3",
+        isinv: "\u2208",
+        it: "\u2062",
+        Itilde: "\u0128",
+        itilde: "\u0129",
+        Iukcy: "\u0406",
+        iukcy: "\u0456",
+        Iuml: "\xCF",
+        iuml: "\xEF",
+        Jcirc: "\u0134",
+        jcirc: "\u0135",
+        Jcy: "\u0419",
+        jcy: "\u0439",
+        Jfr: "\u{1D50D}",
+        jfr: "\u{1D527}",
+        jmath: "\u0237",
+        Jopf: "\u{1D541}",
+        jopf: "\u{1D55B}",
+        Jscr: "\u{1D4A5}",
+        jscr: "\u{1D4BF}",
+        Jsercy: "\u0408",
+        jsercy: "\u0458",
+        Jukcy: "\u0404",
+        jukcy: "\u0454",
+        Kappa: "\u039A",
+        kappa: "\u03BA",
+        kappav: "\u03F0",
+        Kcedil: "\u0136",
+        kcedil: "\u0137",
+        Kcy: "\u041A",
+        kcy: "\u043A",
+        Kfr: "\u{1D50E}",
+        kfr: "\u{1D528}",
+        kgreen: "\u0138",
+        KHcy: "\u0425",
+        khcy: "\u0445",
+        KJcy: "\u040C",
+        kjcy: "\u045C",
+        Kopf: "\u{1D542}",
+        kopf: "\u{1D55C}",
+        Kscr: "\u{1D4A6}",
+        kscr: "\u{1D4C0}",
+        lAarr: "\u21DA",
+        Lacute: "\u0139",
+        lacute: "\u013A",
+        laemptyv: "\u29B4",
+        lagran: "\u2112",
+        Lambda: "\u039B",
+        lambda: "\u03BB",
+        Lang: "\u27EA",
+        lang: "\u27E8",
+        langd: "\u2991",
+        langle: "\u27E8",
+        lap: "\u2A85",
+        Laplacetrf: "\u2112",
+        laquo: "\xAB",
+        Larr: "\u219E",
+        lArr: "\u21D0",
+        larr: "\u2190",
+        larrb: "\u21E4",
+        larrbfs: "\u291F",
+        larrfs: "\u291D",
+        larrhk: "\u21A9",
+        larrlp: "\u21AB",
+        larrpl: "\u2939",
+        larrsim: "\u2973",
+        larrtl: "\u21A2",
+        lat: "\u2AAB",
+        lAtail: "\u291B",
+        latail: "\u2919",
+        late: "\u2AAD",
+        lates: "\u2AAD\uFE00",
+        lBarr: "\u290E",
+        lbarr: "\u290C",
+        lbbrk: "\u2772",
+        lbrace: "{",
+        lbrack: "[",
+        lbrke: "\u298B",
+        lbrksld: "\u298F",
+        lbrkslu: "\u298D",
+        Lcaron: "\u013D",
+        lcaron: "\u013E",
+        Lcedil: "\u013B",
+        lcedil: "\u013C",
+        lceil: "\u2308",
+        lcub: "{",
+        Lcy: "\u041B",
+        lcy: "\u043B",
+        ldca: "\u2936",
+        ldquo: "\u201C",
+        ldquor: "\u201E",
+        ldrdhar: "\u2967",
+        ldrushar: "\u294B",
+        ldsh: "\u21B2",
+        lE: "\u2266",
+        le: "\u2264",
+        LeftAngleBracket: "\u27E8",
+        LeftArrow: "\u2190",
+        Leftarrow: "\u21D0",
+        leftarrow: "\u2190",
+        LeftArrowBar: "\u21E4",
+        LeftArrowRightArrow: "\u21C6",
+        leftarrowtail: "\u21A2",
+        LeftCeiling: "\u2308",
+        LeftDoubleBracket: "\u27E6",
+        LeftDownTeeVector: "\u2961",
+        LeftDownVector: "\u21C3",
+        LeftDownVectorBar: "\u2959",
+        LeftFloor: "\u230A",
+        leftharpoondown: "\u21BD",
+        leftharpoonup: "\u21BC",
+        leftleftarrows: "\u21C7",
+        LeftRightArrow: "\u2194",
+        Leftrightarrow: "\u21D4",
+        leftrightarrow: "\u2194",
+        leftrightarrows: "\u21C6",
+        leftrightharpoons: "\u21CB",
+        leftrightsquigarrow: "\u21AD",
+        LeftRightVector: "\u294E",
+        LeftTee: "\u22A3",
+        LeftTeeArrow: "\u21A4",
+        LeftTeeVector: "\u295A",
+        leftthreetimes: "\u22CB",
+        LeftTriangle: "\u22B2",
+        LeftTriangleBar: "\u29CF",
+        LeftTriangleEqual: "\u22B4",
+        LeftUpDownVector: "\u2951",
+        LeftUpTeeVector: "\u2960",
+        LeftUpVector: "\u21BF",
+        LeftUpVectorBar: "\u2958",
+        LeftVector: "\u21BC",
+        LeftVectorBar: "\u2952",
+        lEg: "\u2A8B",
+        leg: "\u22DA",
+        leq: "\u2264",
+        leqq: "\u2266",
+        leqslant: "\u2A7D",
+        les: "\u2A7D",
+        lescc: "\u2AA8",
+        lesdot: "\u2A7F",
+        lesdoto: "\u2A81",
+        lesdotor: "\u2A83",
+        lesg: "\u22DA\uFE00",
+        lesges: "\u2A93",
+        lessapprox: "\u2A85",
+        lessdot: "\u22D6",
+        lesseqgtr: "\u22DA",
+        lesseqqgtr: "\u2A8B",
+        LessEqualGreater: "\u22DA",
+        LessFullEqual: "\u2266",
+        LessGreater: "\u2276",
+        lessgtr: "\u2276",
+        LessLess: "\u2AA1",
+        lesssim: "\u2272",
+        LessSlantEqual: "\u2A7D",
+        LessTilde: "\u2272",
+        lfisht: "\u297C",
+        lfloor: "\u230A",
+        Lfr: "\u{1D50F}",
+        lfr: "\u{1D529}",
+        lg: "\u2276",
+        lgE: "\u2A91",
+        lHar: "\u2962",
+        lhard: "\u21BD",
+        lharu: "\u21BC",
+        lharul: "\u296A",
+        lhblk: "\u2584",
+        LJcy: "\u0409",
+        ljcy: "\u0459",
+        Ll: "\u22D8",
+        ll: "\u226A",
+        llarr: "\u21C7",
+        llcorner: "\u231E",
+        Lleftarrow: "\u21DA",
+        llhard: "\u296B",
+        lltri: "\u25FA",
+        Lmidot: "\u013F",
+        lmidot: "\u0140",
+        lmoust: "\u23B0",
+        lmoustache: "\u23B0",
+        lnap: "\u2A89",
+        lnapprox: "\u2A89",
+        lnE: "\u2268",
+        lne: "\u2A87",
+        lneq: "\u2A87",
+        lneqq: "\u2268",
+        lnsim: "\u22E6",
+        loang: "\u27EC",
+        loarr: "\u21FD",
+        lobrk: "\u27E6",
+        LongLeftArrow: "\u27F5",
+        Longleftarrow: "\u27F8",
+        longleftarrow: "\u27F5",
+        LongLeftRightArrow: "\u27F7",
+        Longleftrightarrow: "\u27FA",
+        longleftrightarrow: "\u27F7",
+        longmapsto: "\u27FC",
+        LongRightArrow: "\u27F6",
+        Longrightarrow: "\u27F9",
+        longrightarrow: "\u27F6",
+        looparrowleft: "\u21AB",
+        looparrowright: "\u21AC",
+        lopar: "\u2985",
+        Lopf: "\u{1D543}",
+        lopf: "\u{1D55D}",
+        loplus: "\u2A2D",
+        lotimes: "\u2A34",
+        lowast: "\u2217",
+        lowbar: "_",
+        LowerLeftArrow: "\u2199",
+        LowerRightArrow: "\u2198",
+        loz: "\u25CA",
+        lozenge: "\u25CA",
+        lozf: "\u29EB",
+        lpar: "(",
+        lparlt: "\u2993",
+        lrarr: "\u21C6",
+        lrcorner: "\u231F",
+        lrhar: "\u21CB",
+        lrhard: "\u296D",
+        lrm: "\u200E",
+        lrtri: "\u22BF",
+        lsaquo: "\u2039",
+        Lscr: "\u2112",
+        lscr: "\u{1D4C1}",
+        Lsh: "\u21B0",
+        lsh: "\u21B0",
+        lsim: "\u2272",
+        lsime: "\u2A8D",
+        lsimg: "\u2A8F",
+        lsqb: "[",
+        lsquo: "\u2018",
+        lsquor: "\u201A",
+        Lstrok: "\u0141",
+        lstrok: "\u0142",
+        Lt: "\u226A",
+        LT: "<",
+        lt: "<",
+        ltcc: "\u2AA6",
+        ltcir: "\u2A79",
+        ltdot: "\u22D6",
+        lthree: "\u22CB",
+        ltimes: "\u22C9",
+        ltlarr: "\u2976",
+        ltquest: "\u2A7B",
+        ltri: "\u25C3",
+        ltrie: "\u22B4",
+        ltrif: "\u25C2",
+        ltrPar: "\u2996",
+        lurdshar: "\u294A",
+        luruhar: "\u2966",
+        lvertneqq: "\u2268\uFE00",
+        lvnE: "\u2268\uFE00",
+        macr: "\xAF",
+        male: "\u2642",
+        malt: "\u2720",
+        maltese: "\u2720",
+        Map: "\u2905",
+        map: "\u21A6",
+        mapsto: "\u21A6",
+        mapstodown: "\u21A7",
+        mapstoleft: "\u21A4",
+        mapstoup: "\u21A5",
+        marker: "\u25AE",
+        mcomma: "\u2A29",
+        Mcy: "\u041C",
+        mcy: "\u043C",
+        mdash: "\u2014",
+        mDDot: "\u223A",
+        measuredangle: "\u2221",
+        MediumSpace: "\u205F",
+        Mellintrf: "\u2133",
+        Mfr: "\u{1D510}",
+        mfr: "\u{1D52A}",
+        mho: "\u2127",
+        micro: "\xB5",
+        mid: "\u2223",
+        midast: "*",
+        midcir: "\u2AF0",
+        middot: "\xB7",
+        minus: "\u2212",
+        minusb: "\u229F",
+        minusd: "\u2238",
+        minusdu: "\u2A2A",
+        MinusPlus: "\u2213",
+        mlcp: "\u2ADB",
+        mldr: "\u2026",
+        mnplus: "\u2213",
+        models: "\u22A7",
+        Mopf: "\u{1D544}",
+        mopf: "\u{1D55E}",
+        mp: "\u2213",
+        Mscr: "\u2133",
+        mscr: "\u{1D4C2}",
+        mstpos: "\u223E",
+        Mu: "\u039C",
+        mu: "\u03BC",
+        multimap: "\u22B8",
+        mumap: "\u22B8",
+        nabla: "\u2207",
+        Nacute: "\u0143",
+        nacute: "\u0144",
+        nang: "\u2220\u20D2",
+        nap: "\u2249",
+        napE: "\u2A70\u0338",
+        napid: "\u224B\u0338",
+        napos: "\u0149",
+        napprox: "\u2249",
+        natur: "\u266E",
+        natural: "\u266E",
+        naturals: "\u2115",
+        nbsp: "\xA0",
+        nbump: "\u224E\u0338",
+        nbumpe: "\u224F\u0338",
+        ncap: "\u2A43",
+        Ncaron: "\u0147",
+        ncaron: "\u0148",
+        Ncedil: "\u0145",
+        ncedil: "\u0146",
+        ncong: "\u2247",
+        ncongdot: "\u2A6D\u0338",
+        ncup: "\u2A42",
+        Ncy: "\u041D",
+        ncy: "\u043D",
+        ndash: "\u2013",
+        ne: "\u2260",
+        nearhk: "\u2924",
+        neArr: "\u21D7",
+        nearr: "\u2197",
+        nearrow: "\u2197",
+        nedot: "\u2250\u0338",
+        NegativeMediumSpace: "\u200B",
+        NegativeThickSpace: "\u200B",
+        NegativeThinSpace: "\u200B",
+        NegativeVeryThinSpace: "\u200B",
+        nequiv: "\u2262",
+        nesear: "\u2928",
+        nesim: "\u2242\u0338",
+        NestedGreaterGreater: "\u226B",
+        NestedLessLess: "\u226A",
+        NewLine: "\n",
+        nexist: "\u2204",
+        nexists: "\u2204",
+        Nfr: "\u{1D511}",
+        nfr: "\u{1D52B}",
+        ngE: "\u2267\u0338",
+        nge: "\u2271",
+        ngeq: "\u2271",
+        ngeqq: "\u2267\u0338",
+        ngeqslant: "\u2A7E\u0338",
+        nges: "\u2A7E\u0338",
+        nGg: "\u22D9\u0338",
+        ngsim: "\u2275",
+        nGt: "\u226B\u20D2",
+        ngt: "\u226F",
+        ngtr: "\u226F",
+        nGtv: "\u226B\u0338",
+        nhArr: "\u21CE",
+        nharr: "\u21AE",
+        nhpar: "\u2AF2",
+        ni: "\u220B",
+        nis: "\u22FC",
+        nisd: "\u22FA",
+        niv: "\u220B",
+        NJcy: "\u040A",
+        njcy: "\u045A",
+        nlArr: "\u21CD",
+        nlarr: "\u219A",
+        nldr: "\u2025",
+        nlE: "\u2266\u0338",
+        nle: "\u2270",
+        nLeftarrow: "\u21CD",
+        nleftarrow: "\u219A",
+        nLeftrightarrow: "\u21CE",
+        nleftrightarrow: "\u21AE",
+        nleq: "\u2270",
+        nleqq: "\u2266\u0338",
+        nleqslant: "\u2A7D\u0338",
+        nles: "\u2A7D\u0338",
+        nless: "\u226E",
+        nLl: "\u22D8\u0338",
+        nlsim: "\u2274",
+        nLt: "\u226A\u20D2",
+        nlt: "\u226E",
+        nltri: "\u22EA",
+        nltrie: "\u22EC",
+        nLtv: "\u226A\u0338",
+        nmid: "\u2224",
+        NoBreak: "\u2060",
+        NonBreakingSpace: "\xA0",
+        Nopf: "\u2115",
+        nopf: "\u{1D55F}",
+        Not: "\u2AEC",
+        not: "\xAC",
+        NotCongruent: "\u2262",
+        NotCupCap: "\u226D",
+        NotDoubleVerticalBar: "\u2226",
+        NotElement: "\u2209",
+        NotEqual: "\u2260",
+        NotEqualTilde: "\u2242\u0338",
+        NotExists: "\u2204",
+        NotGreater: "\u226F",
+        NotGreaterEqual: "\u2271",
+        NotGreaterFullEqual: "\u2267\u0338",
+        NotGreaterGreater: "\u226B\u0338",
+        NotGreaterLess: "\u2279",
+        NotGreaterSlantEqual: "\u2A7E\u0338",
+        NotGreaterTilde: "\u2275",
+        NotHumpDownHump: "\u224E\u0338",
+        NotHumpEqual: "\u224F\u0338",
+        notin: "\u2209",
+        notindot: "\u22F5\u0338",
+        notinE: "\u22F9\u0338",
+        notinva: "\u2209",
+        notinvb: "\u22F7",
+        notinvc: "\u22F6",
+        NotLeftTriangle: "\u22EA",
+        NotLeftTriangleBar: "\u29CF\u0338",
+        NotLeftTriangleEqual: "\u22EC",
+        NotLess: "\u226E",
+        NotLessEqual: "\u2270",
+        NotLessGreater: "\u2278",
+        NotLessLess: "\u226A\u0338",
+        NotLessSlantEqual: "\u2A7D\u0338",
+        NotLessTilde: "\u2274",
+        NotNestedGreaterGreater: "\u2AA2\u0338",
+        NotNestedLessLess: "\u2AA1\u0338",
+        notni: "\u220C",
+        notniva: "\u220C",
+        notnivb: "\u22FE",
+        notnivc: "\u22FD",
+        NotPrecedes: "\u2280",
+        NotPrecedesEqual: "\u2AAF\u0338",
+        NotPrecedesSlantEqual: "\u22E0",
+        NotReverseElement: "\u220C",
+        NotRightTriangle: "\u22EB",
+        NotRightTriangleBar: "\u29D0\u0338",
+        NotRightTriangleEqual: "\u22ED",
+        NotSquareSubset: "\u228F\u0338",
+        NotSquareSubsetEqual: "\u22E2",
+        NotSquareSuperset: "\u2290\u0338",
+        NotSquareSupersetEqual: "\u22E3",
+        NotSubset: "\u2282\u20D2",
+        NotSubsetEqual: "\u2288",
+        NotSucceeds: "\u2281",
+        NotSucceedsEqual: "\u2AB0\u0338",
+        NotSucceedsSlantEqual: "\u22E1",
+        NotSucceedsTilde: "\u227F\u0338",
+        NotSuperset: "\u2283\u20D2",
+        NotSupersetEqual: "\u2289",
+        NotTilde: "\u2241",
+        NotTildeEqual: "\u2244",
+        NotTildeFullEqual: "\u2247",
+        NotTildeTilde: "\u2249",
+        NotVerticalBar: "\u2224",
+        npar: "\u2226",
+        nparallel: "\u2226",
+        nparsl: "\u2AFD\u20E5",
+        npart: "\u2202\u0338",
+        npolint: "\u2A14",
+        npr: "\u2280",
+        nprcue: "\u22E0",
+        npre: "\u2AAF\u0338",
+        nprec: "\u2280",
+        npreceq: "\u2AAF\u0338",
+        nrArr: "\u21CF",
+        nrarr: "\u219B",
+        nrarrc: "\u2933\u0338",
+        nrarrw: "\u219D\u0338",
+        nRightarrow: "\u21CF",
+        nrightarrow: "\u219B",
+        nrtri: "\u22EB",
+        nrtrie: "\u22ED",
+        nsc: "\u2281",
+        nsccue: "\u22E1",
+        nsce: "\u2AB0\u0338",
+        Nscr: "\u{1D4A9}",
+        nscr: "\u{1D4C3}",
+        nshortmid: "\u2224",
+        nshortparallel: "\u2226",
+        nsim: "\u2241",
+        nsime: "\u2244",
+        nsimeq: "\u2244",
+        nsmid: "\u2224",
+        nspar: "\u2226",
+        nsqsube: "\u22E2",
+        nsqsupe: "\u22E3",
+        nsub: "\u2284",
+        nsubE: "\u2AC5\u0338",
+        nsube: "\u2288",
+        nsubset: "\u2282\u20D2",
+        nsubseteq: "\u2288",
+        nsubseteqq: "\u2AC5\u0338",
+        nsucc: "\u2281",
+        nsucceq: "\u2AB0\u0338",
+        nsup: "\u2285",
+        nsupE: "\u2AC6\u0338",
+        nsupe: "\u2289",
+        nsupset: "\u2283\u20D2",
+        nsupseteq: "\u2289",
+        nsupseteqq: "\u2AC6\u0338",
+        ntgl: "\u2279",
+        Ntilde: "\xD1",
+        ntilde: "\xF1",
+        ntlg: "\u2278",
+        ntriangleleft: "\u22EA",
+        ntrianglelefteq: "\u22EC",
+        ntriangleright: "\u22EB",
+        ntrianglerighteq: "\u22ED",
+        Nu: "\u039D",
+        nu: "\u03BD",
+        num: "#",
+        numero: "\u2116",
+        numsp: "\u2007",
+        nvap: "\u224D\u20D2",
+        nVDash: "\u22AF",
+        nVdash: "\u22AE",
+        nvDash: "\u22AD",
+        nvdash: "\u22AC",
+        nvge: "\u2265\u20D2",
+        nvgt: ">\u20D2",
+        nvHarr: "\u2904",
+        nvinfin: "\u29DE",
+        nvlArr: "\u2902",
+        nvle: "\u2264\u20D2",
+        nvlt: "<\u20D2",
+        nvltrie: "\u22B4\u20D2",
+        nvrArr: "\u2903",
+        nvrtrie: "\u22B5\u20D2",
+        nvsim: "\u223C\u20D2",
+        nwarhk: "\u2923",
+        nwArr: "\u21D6",
+        nwarr: "\u2196",
+        nwarrow: "\u2196",
+        nwnear: "\u2927",
+        Oacute: "\xD3",
+        oacute: "\xF3",
+        oast: "\u229B",
+        ocir: "\u229A",
+        Ocirc: "\xD4",
+        ocirc: "\xF4",
+        Ocy: "\u041E",
+        ocy: "\u043E",
+        odash: "\u229D",
+        Odblac: "\u0150",
+        odblac: "\u0151",
+        odiv: "\u2A38",
+        odot: "\u2299",
+        odsold: "\u29BC",
+        OElig: "\u0152",
+        oelig: "\u0153",
+        ofcir: "\u29BF",
+        Ofr: "\u{1D512}",
+        ofr: "\u{1D52C}",
+        ogon: "\u02DB",
+        Ograve: "\xD2",
+        ograve: "\xF2",
+        ogt: "\u29C1",
+        ohbar: "\u29B5",
+        ohm: "\u03A9",
+        oint: "\u222E",
+        olarr: "\u21BA",
+        olcir: "\u29BE",
+        olcross: "\u29BB",
+        oline: "\u203E",
+        olt: "\u29C0",
+        Omacr: "\u014C",
+        omacr: "\u014D",
+        Omega: "\u03A9",
+        omega: "\u03C9",
+        Omicron: "\u039F",
+        omicron: "\u03BF",
+        omid: "\u29B6",
+        ominus: "\u2296",
+        Oopf: "\u{1D546}",
+        oopf: "\u{1D560}",
+        opar: "\u29B7",
+        OpenCurlyDoubleQuote: "\u201C",
+        OpenCurlyQuote: "\u2018",
+        operp: "\u29B9",
+        oplus: "\u2295",
+        Or: "\u2A54",
+        or: "\u2228",
+        orarr: "\u21BB",
+        ord: "\u2A5D",
+        order: "\u2134",
+        orderof: "\u2134",
+        ordf: "\xAA",
+        ordm: "\xBA",
+        origof: "\u22B6",
+        oror: "\u2A56",
+        orslope: "\u2A57",
+        orv: "\u2A5B",
+        oS: "\u24C8",
+        Oscr: "\u{1D4AA}",
+        oscr: "\u2134",
+        Oslash: "\xD8",
+        oslash: "\xF8",
+        osol: "\u2298",
+        Otilde: "\xD5",
+        otilde: "\xF5",
+        Otimes: "\u2A37",
+        otimes: "\u2297",
+        otimesas: "\u2A36",
+        Ouml: "\xD6",
+        ouml: "\xF6",
+        ovbar: "\u233D",
+        OverBar: "\u203E",
+        OverBrace: "\u23DE",
+        OverBracket: "\u23B4",
+        OverParenthesis: "\u23DC",
+        par: "\u2225",
+        para: "\xB6",
+        parallel: "\u2225",
+        parsim: "\u2AF3",
+        parsl: "\u2AFD",
+        part: "\u2202",
+        PartialD: "\u2202",
+        Pcy: "\u041F",
+        pcy: "\u043F",
+        percnt: "%",
+        period: ".",
+        permil: "\u2030",
+        perp: "\u22A5",
+        pertenk: "\u2031",
+        Pfr: "\u{1D513}",
+        pfr: "\u{1D52D}",
+        Phi: "\u03A6",
+        phi: "\u03C6",
+        phiv: "\u03D5",
+        phmmat: "\u2133",
+        phone: "\u260E",
+        Pi: "\u03A0",
+        pi: "\u03C0",
+        pitchfork: "\u22D4",
+        piv: "\u03D6",
+        planck: "\u210F",
+        planckh: "\u210E",
+        plankv: "\u210F",
+        plus: "+",
+        plusacir: "\u2A23",
+        plusb: "\u229E",
+        pluscir: "\u2A22",
+        plusdo: "\u2214",
+        plusdu: "\u2A25",
+        pluse: "\u2A72",
+        PlusMinus: "\xB1",
+        plusmn: "\xB1",
+        plussim: "\u2A26",
+        plustwo: "\u2A27",
+        pm: "\xB1",
+        Poincareplane: "\u210C",
+        pointint: "\u2A15",
+        Popf: "\u2119",
+        popf: "\u{1D561}",
+        pound: "\xA3",
+        Pr: "\u2ABB",
+        pr: "\u227A",
+        prap: "\u2AB7",
+        prcue: "\u227C",
+        prE: "\u2AB3",
+        pre: "\u2AAF",
+        prec: "\u227A",
+        precapprox: "\u2AB7",
+        preccurlyeq: "\u227C",
+        Precedes: "\u227A",
+        PrecedesEqual: "\u2AAF",
+        PrecedesSlantEqual: "\u227C",
+        PrecedesTilde: "\u227E",
+        preceq: "\u2AAF",
+        precnapprox: "\u2AB9",
+        precneqq: "\u2AB5",
+        precnsim: "\u22E8",
+        precsim: "\u227E",
+        Prime: "\u2033",
+        prime: "\u2032",
+        primes: "\u2119",
+        prnap: "\u2AB9",
+        prnE: "\u2AB5",
+        prnsim: "\u22E8",
+        prod: "\u220F",
+        Product: "\u220F",
+        profalar: "\u232E",
+        profline: "\u2312",
+        profsurf: "\u2313",
+        prop: "\u221D",
+        Proportion: "\u2237",
+        Proportional: "\u221D",
+        propto: "\u221D",
+        prsim: "\u227E",
+        prurel: "\u22B0",
+        Pscr: "\u{1D4AB}",
+        pscr: "\u{1D4C5}",
+        Psi: "\u03A8",
+        psi: "\u03C8",
+        puncsp: "\u2008",
+        Qfr: "\u{1D514}",
+        qfr: "\u{1D52E}",
+        qint: "\u2A0C",
+        Qopf: "\u211A",
+        qopf: "\u{1D562}",
+        qprime: "\u2057",
+        Qscr: "\u{1D4AC}",
+        qscr: "\u{1D4C6}",
+        quaternions: "\u210D",
+        quatint: "\u2A16",
+        quest: "?",
+        questeq: "\u225F",
+        QUOT: '"',
+        quot: '"',
+        rAarr: "\u21DB",
+        race: "\u223D\u0331",
+        Racute: "\u0154",
+        racute: "\u0155",
+        radic: "\u221A",
+        raemptyv: "\u29B3",
+        Rang: "\u27EB",
+        rang: "\u27E9",
+        rangd: "\u2992",
+        range: "\u29A5",
+        rangle: "\u27E9",
+        raquo: "\xBB",
+        Rarr: "\u21A0",
+        rArr: "\u21D2",
+        rarr: "\u2192",
+        rarrap: "\u2975",
+        rarrb: "\u21E5",
+        rarrbfs: "\u2920",
+        rarrc: "\u2933",
+        rarrfs: "\u291E",
+        rarrhk: "\u21AA",
+        rarrlp: "\u21AC",
+        rarrpl: "\u2945",
+        rarrsim: "\u2974",
+        Rarrtl: "\u2916",
+        rarrtl: "\u21A3",
+        rarrw: "\u219D",
+        rAtail: "\u291C",
+        ratail: "\u291A",
+        ratio: "\u2236",
+        rationals: "\u211A",
+        RBarr: "\u2910",
+        rBarr: "\u290F",
+        rbarr: "\u290D",
+        rbbrk: "\u2773",
+        rbrace: "}",
+        rbrack: "]",
+        rbrke: "\u298C",
+        rbrksld: "\u298E",
+        rbrkslu: "\u2990",
+        Rcaron: "\u0158",
+        rcaron: "\u0159",
+        Rcedil: "\u0156",
+        rcedil: "\u0157",
+        rceil: "\u2309",
+        rcub: "}",
+        Rcy: "\u0420",
+        rcy: "\u0440",
+        rdca: "\u2937",
+        rdldhar: "\u2969",
+        rdquo: "\u201D",
+        rdquor: "\u201D",
+        rdsh: "\u21B3",
+        Re: "\u211C",
+        real: "\u211C",
+        realine: "\u211B",
+        realpart: "\u211C",
+        reals: "\u211D",
+        rect: "\u25AD",
+        REG: "\xAE",
+        reg: "\xAE",
+        ReverseElement: "\u220B",
+        ReverseEquilibrium: "\u21CB",
+        ReverseUpEquilibrium: "\u296F",
+        rfisht: "\u297D",
+        rfloor: "\u230B",
+        Rfr: "\u211C",
+        rfr: "\u{1D52F}",
+        rHar: "\u2964",
+        rhard: "\u21C1",
+        rharu: "\u21C0",
+        rharul: "\u296C",
+        Rho: "\u03A1",
+        rho: "\u03C1",
+        rhov: "\u03F1",
+        RightAngleBracket: "\u27E9",
+        RightArrow: "\u2192",
+        Rightarrow: "\u21D2",
+        rightarrow: "\u2192",
+        RightArrowBar: "\u21E5",
+        RightArrowLeftArrow: "\u21C4",
+        rightarrowtail: "\u21A3",
+        RightCeiling: "\u2309",
+        RightDoubleBracket: "\u27E7",
+        RightDownTeeVector: "\u295D",
+        RightDownVector: "\u21C2",
+        RightDownVectorBar: "\u2955",
+        RightFloor: "\u230B",
+        rightharpoondown: "\u21C1",
+        rightharpoonup: "\u21C0",
+        rightleftarrows: "\u21C4",
+        rightleftharpoons: "\u21CC",
+        rightrightarrows: "\u21C9",
+        rightsquigarrow: "\u219D",
+        RightTee: "\u22A2",
+        RightTeeArrow: "\u21A6",
+        RightTeeVector: "\u295B",
+        rightthreetimes: "\u22CC",
+        RightTriangle: "\u22B3",
+        RightTriangleBar: "\u29D0",
+        RightTriangleEqual: "\u22B5",
+        RightUpDownVector: "\u294F",
+        RightUpTeeVector: "\u295C",
+        RightUpVector: "\u21BE",
+        RightUpVectorBar: "\u2954",
+        RightVector: "\u21C0",
+        RightVectorBar: "\u2953",
+        ring: "\u02DA",
+        risingdotseq: "\u2253",
+        rlarr: "\u21C4",
+        rlhar: "\u21CC",
+        rlm: "\u200F",
+        rmoust: "\u23B1",
+        rmoustache: "\u23B1",
+        rnmid: "\u2AEE",
+        roang: "\u27ED",
+        roarr: "\u21FE",
+        robrk: "\u27E7",
+        ropar: "\u2986",
+        Ropf: "\u211D",
+        ropf: "\u{1D563}",
+        roplus: "\u2A2E",
+        rotimes: "\u2A35",
+        RoundImplies: "\u2970",
+        rpar: ")",
+        rpargt: "\u2994",
+        rppolint: "\u2A12",
+        rrarr: "\u21C9",
+        Rrightarrow: "\u21DB",
+        rsaquo: "\u203A",
+        Rscr: "\u211B",
+        rscr: "\u{1D4C7}",
+        Rsh: "\u21B1",
+        rsh: "\u21B1",
+        rsqb: "]",
+        rsquo: "\u2019",
+        rsquor: "\u2019",
+        rthree: "\u22CC",
+        rtimes: "\u22CA",
+        rtri: "\u25B9",
+        rtrie: "\u22B5",
+        rtrif: "\u25B8",
+        rtriltri: "\u29CE",
+        RuleDelayed: "\u29F4",
+        ruluhar: "\u2968",
+        rx: "\u211E",
+        Sacute: "\u015A",
+        sacute: "\u015B",
+        sbquo: "\u201A",
+        Sc: "\u2ABC",
+        sc: "\u227B",
+        scap: "\u2AB8",
+        Scaron: "\u0160",
+        scaron: "\u0161",
+        sccue: "\u227D",
+        scE: "\u2AB4",
+        sce: "\u2AB0",
+        Scedil: "\u015E",
+        scedil: "\u015F",
+        Scirc: "\u015C",
+        scirc: "\u015D",
+        scnap: "\u2ABA",
+        scnE: "\u2AB6",
+        scnsim: "\u22E9",
+        scpolint: "\u2A13",
+        scsim: "\u227F",
+        Scy: "\u0421",
+        scy: "\u0441",
+        sdot: "\u22C5",
+        sdotb: "\u22A1",
+        sdote: "\u2A66",
+        searhk: "\u2925",
+        seArr: "\u21D8",
+        searr: "\u2198",
+        searrow: "\u2198",
+        sect: "\xA7",
+        semi: ";",
+        seswar: "\u2929",
+        setminus: "\u2216",
+        setmn: "\u2216",
+        sext: "\u2736",
+        Sfr: "\u{1D516}",
+        sfr: "\u{1D530}",
+        sfrown: "\u2322",
+        sharp: "\u266F",
+        SHCHcy: "\u0429",
+        shchcy: "\u0449",
+        SHcy: "\u0428",
+        shcy: "\u0448",
+        ShortDownArrow: "\u2193",
+        ShortLeftArrow: "\u2190",
+        shortmid: "\u2223",
+        shortparallel: "\u2225",
+        ShortRightArrow: "\u2192",
+        ShortUpArrow: "\u2191",
+        shy: "\xAD",
+        Sigma: "\u03A3",
+        sigma: "\u03C3",
+        sigmaf: "\u03C2",
+        sigmav: "\u03C2",
+        sim: "\u223C",
+        simdot: "\u2A6A",
+        sime: "\u2243",
+        simeq: "\u2243",
+        simg: "\u2A9E",
+        simgE: "\u2AA0",
+        siml: "\u2A9D",
+        simlE: "\u2A9F",
+        simne: "\u2246",
+        simplus: "\u2A24",
+        simrarr: "\u2972",
+        slarr: "\u2190",
+        SmallCircle: "\u2218",
+        smallsetminus: "\u2216",
+        smashp: "\u2A33",
+        smeparsl: "\u29E4",
+        smid: "\u2223",
+        smile: "\u2323",
+        smt: "\u2AAA",
+        smte: "\u2AAC",
+        smtes: "\u2AAC\uFE00",
+        SOFTcy: "\u042C",
+        softcy: "\u044C",
+        sol: "/",
+        solb: "\u29C4",
+        solbar: "\u233F",
+        Sopf: "\u{1D54A}",
+        sopf: "\u{1D564}",
+        spades: "\u2660",
+        spadesuit: "\u2660",
+        spar: "\u2225",
+        sqcap: "\u2293",
+        sqcaps: "\u2293\uFE00",
+        sqcup: "\u2294",
+        sqcups: "\u2294\uFE00",
+        Sqrt: "\u221A",
+        sqsub: "\u228F",
+        sqsube: "\u2291",
+        sqsubset: "\u228F",
+        sqsubseteq: "\u2291",
+        sqsup: "\u2290",
+        sqsupe: "\u2292",
+        sqsupset: "\u2290",
+        sqsupseteq: "\u2292",
+        squ: "\u25A1",
+        Square: "\u25A1",
+        square: "\u25A1",
+        SquareIntersection: "\u2293",
+        SquareSubset: "\u228F",
+        SquareSubsetEqual: "\u2291",
+        SquareSuperset: "\u2290",
+        SquareSupersetEqual: "\u2292",
+        SquareUnion: "\u2294",
+        squarf: "\u25AA",
+        squf: "\u25AA",
+        srarr: "\u2192",
+        Sscr: "\u{1D4AE}",
+        sscr: "\u{1D4C8}",
+        ssetmn: "\u2216",
+        ssmile: "\u2323",
+        sstarf: "\u22C6",
+        Star: "\u22C6",
+        star: "\u2606",
+        starf: "\u2605",
+        straightepsilon: "\u03F5",
+        straightphi: "\u03D5",
+        strns: "\xAF",
+        Sub: "\u22D0",
+        sub: "\u2282",
+        subdot: "\u2ABD",
+        subE: "\u2AC5",
+        sube: "\u2286",
+        subedot: "\u2AC3",
+        submult: "\u2AC1",
+        subnE: "\u2ACB",
+        subne: "\u228A",
+        subplus: "\u2ABF",
+        subrarr: "\u2979",
+        Subset: "\u22D0",
+        subset: "\u2282",
+        subseteq: "\u2286",
+        subseteqq: "\u2AC5",
+        SubsetEqual: "\u2286",
+        subsetneq: "\u228A",
+        subsetneqq: "\u2ACB",
+        subsim: "\u2AC7",
+        subsub: "\u2AD5",
+        subsup: "\u2AD3",
+        succ: "\u227B",
+        succapprox: "\u2AB8",
+        succcurlyeq: "\u227D",
+        Succeeds: "\u227B",
+        SucceedsEqual: "\u2AB0",
+        SucceedsSlantEqual: "\u227D",
+        SucceedsTilde: "\u227F",
+        succeq: "\u2AB0",
+        succnapprox: "\u2ABA",
+        succneqq: "\u2AB6",
+        succnsim: "\u22E9",
+        succsim: "\u227F",
+        SuchThat: "\u220B",
+        Sum: "\u2211",
+        sum: "\u2211",
+        sung: "\u266A",
+        Sup: "\u22D1",
+        sup: "\u2283",
+        sup1: "\xB9",
+        sup2: "\xB2",
+        sup3: "\xB3",
+        supdot: "\u2ABE",
+        supdsub: "\u2AD8",
+        supE: "\u2AC6",
+        supe: "\u2287",
+        supedot: "\u2AC4",
+        Superset: "\u2283",
+        SupersetEqual: "\u2287",
+        suphsol: "\u27C9",
+        suphsub: "\u2AD7",
+        suplarr: "\u297B",
+        supmult: "\u2AC2",
+        supnE: "\u2ACC",
+        supne: "\u228B",
+        supplus: "\u2AC0",
+        Supset: "\u22D1",
+        supset: "\u2283",
+        supseteq: "\u2287",
+        supseteqq: "\u2AC6",
+        supsetneq: "\u228B",
+        supsetneqq: "\u2ACC",
+        supsim: "\u2AC8",
+        supsub: "\u2AD4",
+        supsup: "\u2AD6",
+        swarhk: "\u2926",
+        swArr: "\u21D9",
+        swarr: "\u2199",
+        swarrow: "\u2199",
+        swnwar: "\u292A",
+        szlig: "\xDF",
+        Tab: "	",
+        target: "\u2316",
+        Tau: "\u03A4",
+        tau: "\u03C4",
+        tbrk: "\u23B4",
+        Tcaron: "\u0164",
+        tcaron: "\u0165",
+        Tcedil: "\u0162",
+        tcedil: "\u0163",
+        Tcy: "\u0422",
+        tcy: "\u0442",
+        tdot: "\u20DB",
+        telrec: "\u2315",
+        Tfr: "\u{1D517}",
+        tfr: "\u{1D531}",
+        there4: "\u2234",
+        Therefore: "\u2234",
+        therefore: "\u2234",
+        Theta: "\u0398",
+        theta: "\u03B8",
+        thetasym: "\u03D1",
+        thetav: "\u03D1",
+        thickapprox: "\u2248",
+        thicksim: "\u223C",
+        ThickSpace: "\u205F\u200A",
+        thinsp: "\u2009",
+        ThinSpace: "\u2009",
+        thkap: "\u2248",
+        thksim: "\u223C",
+        THORN: "\xDE",
+        thorn: "\xFE",
+        Tilde: "\u223C",
+        tilde: "\u02DC",
+        TildeEqual: "\u2243",
+        TildeFullEqual: "\u2245",
+        TildeTilde: "\u2248",
+        times: "\xD7",
+        timesb: "\u22A0",
+        timesbar: "\u2A31",
+        timesd: "\u2A30",
+        tint: "\u222D",
+        toea: "\u2928",
+        top: "\u22A4",
+        topbot: "\u2336",
+        topcir: "\u2AF1",
+        Topf: "\u{1D54B}",
+        topf: "\u{1D565}",
+        topfork: "\u2ADA",
+        tosa: "\u2929",
+        tprime: "\u2034",
+        TRADE: "\u2122",
+        trade: "\u2122",
+        triangle: "\u25B5",
+        triangledown: "\u25BF",
+        triangleleft: "\u25C3",
+        trianglelefteq: "\u22B4",
+        triangleq: "\u225C",
+        triangleright: "\u25B9",
+        trianglerighteq: "\u22B5",
+        tridot: "\u25EC",
+        trie: "\u225C",
+        triminus: "\u2A3A",
+        TripleDot: "\u20DB",
+        triplus: "\u2A39",
+        trisb: "\u29CD",
+        tritime: "\u2A3B",
+        trpezium: "\u23E2",
+        Tscr: "\u{1D4AF}",
+        tscr: "\u{1D4C9}",
+        TScy: "\u0426",
+        tscy: "\u0446",
+        TSHcy: "\u040B",
+        tshcy: "\u045B",
+        Tstrok: "\u0166",
+        tstrok: "\u0167",
+        twixt: "\u226C",
+        twoheadleftarrow: "\u219E",
+        twoheadrightarrow: "\u21A0",
+        Uacute: "\xDA",
+        uacute: "\xFA",
+        Uarr: "\u219F",
+        uArr: "\u21D1",
+        uarr: "\u2191",
+        Uarrocir: "\u2949",
+        Ubrcy: "\u040E",
+        ubrcy: "\u045E",
+        Ubreve: "\u016C",
+        ubreve: "\u016D",
+        Ucirc: "\xDB",
+        ucirc: "\xFB",
+        Ucy: "\u0423",
+        ucy: "\u0443",
+        udarr: "\u21C5",
+        Udblac: "\u0170",
+        udblac: "\u0171",
+        udhar: "\u296E",
+        ufisht: "\u297E",
+        Ufr: "\u{1D518}",
+        ufr: "\u{1D532}",
+        Ugrave: "\xD9",
+        ugrave: "\xF9",
+        uHar: "\u2963",
+        uharl: "\u21BF",
+        uharr: "\u21BE",
+        uhblk: "\u2580",
+        ulcorn: "\u231C",
+        ulcorner: "\u231C",
+        ulcrop: "\u230F",
+        ultri: "\u25F8",
+        Umacr: "\u016A",
+        umacr: "\u016B",
+        uml: "\xA8",
+        UnderBar: "_",
+        UnderBrace: "\u23DF",
+        UnderBracket: "\u23B5",
+        UnderParenthesis: "\u23DD",
+        Union: "\u22C3",
+        UnionPlus: "\u228E",
+        Uogon: "\u0172",
+        uogon: "\u0173",
+        Uopf: "\u{1D54C}",
+        uopf: "\u{1D566}",
+        UpArrow: "\u2191",
+        Uparrow: "\u21D1",
+        uparrow: "\u2191",
+        UpArrowBar: "\u2912",
+        UpArrowDownArrow: "\u21C5",
+        UpDownArrow: "\u2195",
+        Updownarrow: "\u21D5",
+        updownarrow: "\u2195",
+        UpEquilibrium: "\u296E",
+        upharpoonleft: "\u21BF",
+        upharpoonright: "\u21BE",
+        uplus: "\u228E",
+        UpperLeftArrow: "\u2196",
+        UpperRightArrow: "\u2197",
+        Upsi: "\u03D2",
+        upsi: "\u03C5",
+        upsih: "\u03D2",
+        Upsilon: "\u03A5",
+        upsilon: "\u03C5",
+        UpTee: "\u22A5",
+        UpTeeArrow: "\u21A5",
+        upuparrows: "\u21C8",
+        urcorn: "\u231D",
+        urcorner: "\u231D",
+        urcrop: "\u230E",
+        Uring: "\u016E",
+        uring: "\u016F",
+        urtri: "\u25F9",
+        Uscr: "\u{1D4B0}",
+        uscr: "\u{1D4CA}",
+        utdot: "\u22F0",
+        Utilde: "\u0168",
+        utilde: "\u0169",
+        utri: "\u25B5",
+        utrif: "\u25B4",
+        uuarr: "\u21C8",
+        Uuml: "\xDC",
+        uuml: "\xFC",
+        uwangle: "\u29A7",
+        vangrt: "\u299C",
+        varepsilon: "\u03F5",
+        varkappa: "\u03F0",
+        varnothing: "\u2205",
+        varphi: "\u03D5",
+        varpi: "\u03D6",
+        varpropto: "\u221D",
+        vArr: "\u21D5",
+        varr: "\u2195",
+        varrho: "\u03F1",
+        varsigma: "\u03C2",
+        varsubsetneq: "\u228A\uFE00",
+        varsubsetneqq: "\u2ACB\uFE00",
+        varsupsetneq: "\u228B\uFE00",
+        varsupsetneqq: "\u2ACC\uFE00",
+        vartheta: "\u03D1",
+        vartriangleleft: "\u22B2",
+        vartriangleright: "\u22B3",
+        Vbar: "\u2AEB",
+        vBar: "\u2AE8",
+        vBarv: "\u2AE9",
+        Vcy: "\u0412",
+        vcy: "\u0432",
+        VDash: "\u22AB",
+        Vdash: "\u22A9",
+        vDash: "\u22A8",
+        vdash: "\u22A2",
+        Vdashl: "\u2AE6",
+        Vee: "\u22C1",
+        vee: "\u2228",
+        veebar: "\u22BB",
+        veeeq: "\u225A",
+        vellip: "\u22EE",
+        Verbar: "\u2016",
+        verbar: "|",
+        Vert: "\u2016",
+        vert: "|",
+        VerticalBar: "\u2223",
+        VerticalLine: "|",
+        VerticalSeparator: "\u2758",
+        VerticalTilde: "\u2240",
+        VeryThinSpace: "\u200A",
+        Vfr: "\u{1D519}",
+        vfr: "\u{1D533}",
+        vltri: "\u22B2",
+        vnsub: "\u2282\u20D2",
+        vnsup: "\u2283\u20D2",
+        Vopf: "\u{1D54D}",
+        vopf: "\u{1D567}",
+        vprop: "\u221D",
+        vrtri: "\u22B3",
+        Vscr: "\u{1D4B1}",
+        vscr: "\u{1D4CB}",
+        vsubnE: "\u2ACB\uFE00",
+        vsubne: "\u228A\uFE00",
+        vsupnE: "\u2ACC\uFE00",
+        vsupne: "\u228B\uFE00",
+        Vvdash: "\u22AA",
+        vzigzag: "\u299A",
+        Wcirc: "\u0174",
+        wcirc: "\u0175",
+        wedbar: "\u2A5F",
+        Wedge: "\u22C0",
+        wedge: "\u2227",
+        wedgeq: "\u2259",
+        weierp: "\u2118",
+        Wfr: "\u{1D51A}",
+        wfr: "\u{1D534}",
+        Wopf: "\u{1D54E}",
+        wopf: "\u{1D568}",
+        wp: "\u2118",
+        wr: "\u2240",
+        wreath: "\u2240",
+        Wscr: "\u{1D4B2}",
+        wscr: "\u{1D4CC}",
+        xcap: "\u22C2",
+        xcirc: "\u25EF",
+        xcup: "\u22C3",
+        xdtri: "\u25BD",
+        Xfr: "\u{1D51B}",
+        xfr: "\u{1D535}",
+        xhArr: "\u27FA",
+        xharr: "\u27F7",
+        Xi: "\u039E",
+        xi: "\u03BE",
+        xlArr: "\u27F8",
+        xlarr: "\u27F5",
+        xmap: "\u27FC",
+        xnis: "\u22FB",
+        xodot: "\u2A00",
+        Xopf: "\u{1D54F}",
+        xopf: "\u{1D569}",
+        xoplus: "\u2A01",
+        xotime: "\u2A02",
+        xrArr: "\u27F9",
+        xrarr: "\u27F6",
+        Xscr: "\u{1D4B3}",
+        xscr: "\u{1D4CD}",
+        xsqcup: "\u2A06",
+        xuplus: "\u2A04",
+        xutri: "\u25B3",
+        xvee: "\u22C1",
+        xwedge: "\u22C0",
+        Yacute: "\xDD",
+        yacute: "\xFD",
+        YAcy: "\u042F",
+        yacy: "\u044F",
+        Ycirc: "\u0176",
+        ycirc: "\u0177",
+        Ycy: "\u042B",
+        ycy: "\u044B",
+        yen: "\xA5",
+        Yfr: "\u{1D51C}",
+        yfr: "\u{1D536}",
+        YIcy: "\u0407",
+        yicy: "\u0457",
+        Yopf: "\u{1D550}",
+        yopf: "\u{1D56A}",
+        Yscr: "\u{1D4B4}",
+        yscr: "\u{1D4CE}",
+        YUcy: "\u042E",
+        yucy: "\u044E",
+        Yuml: "\u0178",
+        yuml: "\xFF",
+        Zacute: "\u0179",
+        zacute: "\u017A",
+        Zcaron: "\u017D",
+        zcaron: "\u017E",
+        Zcy: "\u0417",
+        zcy: "\u0437",
+        Zdot: "\u017B",
+        zdot: "\u017C",
+        zeetrf: "\u2128",
+        ZeroWidthSpace: "\u200B",
+        Zeta: "\u0396",
+        zeta: "\u03B6",
+        Zfr: "\u2128",
+        zfr: "\u{1D537}",
+        ZHcy: "\u0416",
+        zhcy: "\u0436",
+        zigrarr: "\u21DD",
+        Zopf: "\u2124",
+        zopf: "\u{1D56B}",
+        Zscr: "\u{1D4B5}",
+        zscr: "\u{1D4CF}",
+        zwj: "\u200D",
+        zwnj: "\u200C"
+      });
+      exports.entityMap = exports.HTML_ENTITIES;
+    }
+  });
+
+  // node_modules/@xmldom/xmldom/lib/sax.js
+  var require_sax = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/sax.js"(exports) {
+      var NAMESPACE = require_conventions().NAMESPACE;
+      var nameStartChar = /[A-Z_a-z\xC0-\xD6\xD8-\xF6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]/;
+      var nameChar = new RegExp("[\\-\\.0-9" + nameStartChar.source.slice(1, -1) + "\\u00B7\\u0300-\\u036F\\u203F-\\u2040]");
+      var tagNamePattern = new RegExp("^" + nameStartChar.source + nameChar.source + "*(?::" + nameStartChar.source + nameChar.source + "*)?$");
+      var S_TAG = 0;
+      var S_ATTR = 1;
+      var S_ATTR_SPACE = 2;
+      var S_EQ = 3;
+      var S_ATTR_NOQUOT_VALUE = 4;
+      var S_ATTR_END = 5;
+      var S_TAG_SPACE = 6;
+      var S_TAG_CLOSE = 7;
+      function ParseError(message, locator) {
+        this.message = message;
+        this.locator = locator;
+        if (Error.captureStackTrace) Error.captureStackTrace(this, ParseError);
+      }
+      ParseError.prototype = new Error();
+      ParseError.prototype.name = ParseError.name;
+      function XMLReader() {
+      }
+      XMLReader.prototype = {
+        parse: function(source, defaultNSMap, entityMap) {
+          var domBuilder = this.domBuilder;
+          domBuilder.startDocument();
+          _copy(defaultNSMap, defaultNSMap = {});
+          parse(
+            source,
+            defaultNSMap,
+            entityMap,
+            domBuilder,
+            this.errorHandler
+          );
+          domBuilder.endDocument();
+        }
+      };
+      function parse(source, defaultNSMapCopy, entityMap, domBuilder, errorHandler) {
+        function fixedFromCharCode(code) {
+          if (code > 65535) {
+            code -= 65536;
+            var surrogate1 = 55296 + (code >> 10), surrogate2 = 56320 + (code & 1023);
+            return String.fromCharCode(surrogate1, surrogate2);
+          } else {
+            return String.fromCharCode(code);
+          }
+        }
+        function entityReplacer(a2) {
+          var k = a2.slice(1, -1);
+          if (Object.hasOwnProperty.call(entityMap, k)) {
+            return entityMap[k];
+          } else if (k.charAt(0) === "#") {
+            return fixedFromCharCode(parseInt(k.substr(1).replace("x", "0x")));
+          } else {
+            errorHandler.error("entity not found:" + a2);
+            return a2;
+          }
+        }
+        function appendText(end2) {
+          if (end2 > start) {
+            var xt = source.substring(start, end2).replace(/&#?\w+;/g, entityReplacer);
+            locator && position(start);
+            domBuilder.characters(xt, 0, end2 - start);
+            start = end2;
+          }
+        }
+        function position(p, m) {
+          while (p >= lineEnd && (m = linePattern.exec(source))) {
+            lineStart = m.index;
+            lineEnd = lineStart + m[0].length;
+            locator.lineNumber++;
+          }
+          locator.columnNumber = p - lineStart + 1;
+        }
+        var lineStart = 0;
+        var lineEnd = 0;
+        var linePattern = /.*(?:\r\n?|\n)|.*$/g;
+        var locator = domBuilder.locator;
+        var parseStack = [{ currentNSMap: defaultNSMapCopy }];
+        var closeMap = {};
+        var start = 0;
+        while (true) {
+          try {
+            var tagStart = source.indexOf("<", start);
+            if (tagStart < 0) {
+              if (!source.substr(start).match(/^\s*$/)) {
+                var doc = domBuilder.doc;
+                var text = doc.createTextNode(source.substr(start));
+                doc.appendChild(text);
+                domBuilder.currentElement = text;
+              }
+              return;
+            }
+            if (tagStart > start) {
+              appendText(tagStart);
+            }
+            switch (source.charAt(tagStart + 1)) {
+              case "/":
+                var end = source.indexOf(">", tagStart + 3);
+                var tagName = source.substring(tagStart + 2, end).replace(/[ \t\n\r]+$/g, "");
+                var config = parseStack.pop();
+                if (end < 0) {
+                  tagName = source.substring(tagStart + 2).replace(/[\s<].*/, "");
+                  errorHandler.error("end tag name: " + tagName + " is not complete:" + config.tagName);
+                  end = tagStart + 1 + tagName.length;
+                } else if (tagName.match(/\s</)) {
+                  tagName = tagName.replace(/[\s<].*/, "");
+                  errorHandler.error("end tag name: " + tagName + " maybe not complete");
+                  end = tagStart + 1 + tagName.length;
+                }
+                var localNSMap = config.localNSMap;
+                var endMatch = config.tagName == tagName;
+                var endIgnoreCaseMach = endMatch || config.tagName && config.tagName.toLowerCase() == tagName.toLowerCase();
+                if (endIgnoreCaseMach) {
+                  domBuilder.endElement(config.uri, config.localName, tagName);
+                  if (localNSMap) {
+                    for (var prefix in localNSMap) {
+                      if (Object.prototype.hasOwnProperty.call(localNSMap, prefix)) {
+                        domBuilder.endPrefixMapping(prefix);
+                      }
+                    }
+                  }
+                  if (!endMatch) {
+                    errorHandler.fatalError("end tag name: " + tagName + " is not match the current start tagName:" + config.tagName);
+                  }
+                } else {
+                  parseStack.push(config);
+                }
+                end++;
+                break;
+              // end elment
+              case "?":
+                locator && position(tagStart);
+                end = parseInstruction(source, tagStart, domBuilder);
+                break;
+              case "!":
+                locator && position(tagStart);
+                end = parseDCC(source, tagStart, domBuilder, errorHandler);
+                break;
+              default:
+                locator && position(tagStart);
+                var el = new ElementAttributes();
+                var currentNSMap = parseStack[parseStack.length - 1].currentNSMap;
+                var end = parseElementStartPart(source, tagStart, el, currentNSMap, entityReplacer, errorHandler);
+                var len = el.length;
+                if (!el.closed && fixSelfClosed(source, end, el.tagName, closeMap)) {
+                  el.closed = true;
+                  if (!entityMap.nbsp) {
+                    errorHandler.warning("unclosed xml attribute");
+                  }
+                }
+                if (locator && len) {
+                  var locator2 = copyLocator(locator, {});
+                  for (var i = 0; i < len; i++) {
+                    var a = el[i];
+                    position(a.offset);
+                    a.locator = copyLocator(locator, {});
+                  }
+                  domBuilder.locator = locator2;
+                  if (appendElement(el, domBuilder, currentNSMap)) {
+                    parseStack.push(el);
+                  }
+                  domBuilder.locator = locator;
+                } else {
+                  if (appendElement(el, domBuilder, currentNSMap)) {
+                    parseStack.push(el);
+                  }
+                }
+                if (NAMESPACE.isHTML(el.uri) && !el.closed) {
+                  end = parseHtmlSpecialContent(source, end, el.tagName, entityReplacer, domBuilder);
+                } else {
+                  end++;
+                }
+            }
+          } catch (e) {
+            if (e instanceof ParseError) {
+              throw e;
+            }
+            errorHandler.error("element parse error: " + e);
+            end = -1;
+          }
+          if (end > start) {
+            start = end;
+          } else {
+            appendText(Math.max(tagStart, start) + 1);
+          }
+        }
+      }
+      function copyLocator(f, t) {
+        t.lineNumber = f.lineNumber;
+        t.columnNumber = f.columnNumber;
+        return t;
+      }
+      function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, errorHandler) {
+        function addAttribute(qname, value2, startIndex) {
+          if (el.attributeNames.hasOwnProperty(qname)) {
+            errorHandler.fatalError("Attribute " + qname + " redefined");
+          }
+          el.addValue(
+            qname,
+            // @see https://www.w3.org/TR/xml/#AVNormalize
+            // since the xmldom sax parser does not "interpret" DTD the following is not implemented:
+            // - recursive replacement of (DTD) entity references
+            // - trimming and collapsing multiple spaces into a single one for attributes that are not of type CDATA
+            value2.replace(/[\t\n\r]/g, " ").replace(/&#?\w+;/g, entityReplacer),
+            startIndex
+          );
+        }
+        var attrName;
+        var value;
+        var p = ++start;
+        var s = S_TAG;
+        while (true) {
+          var c = source.charAt(p);
+          switch (c) {
+            case "=":
+              if (s === S_ATTR) {
+                attrName = source.slice(start, p);
+                s = S_EQ;
+              } else if (s === S_ATTR_SPACE) {
+                s = S_EQ;
+              } else {
+                throw new Error("attribute equal must after attrName");
+              }
+              break;
+            case "'":
+            case '"':
+              if (s === S_EQ || s === S_ATTR) {
+                if (s === S_ATTR) {
+                  errorHandler.warning('attribute value must after "="');
+                  attrName = source.slice(start, p);
+                }
+                start = p + 1;
+                p = source.indexOf(c, start);
+                if (p > 0) {
+                  value = source.slice(start, p);
+                  addAttribute(attrName, value, start - 1);
+                  s = S_ATTR_END;
+                } else {
+                  throw new Error("attribute value no end '" + c + "' match");
+                }
+              } else if (s == S_ATTR_NOQUOT_VALUE) {
+                value = source.slice(start, p);
+                addAttribute(attrName, value, start);
+                errorHandler.warning('attribute "' + attrName + '" missed start quot(' + c + ")!!");
+                start = p + 1;
+                s = S_ATTR_END;
+              } else {
+                throw new Error('attribute value must after "="');
+              }
+              break;
+            case "/":
+              switch (s) {
+                case S_TAG:
+                  el.setTagName(source.slice(start, p));
+                case S_ATTR_END:
+                case S_TAG_SPACE:
+                case S_TAG_CLOSE:
+                  s = S_TAG_CLOSE;
+                  el.closed = true;
+                case S_ATTR_NOQUOT_VALUE:
+                case S_ATTR:
+                  break;
+                case S_ATTR_SPACE:
+                  el.closed = true;
+                  break;
+                //case S_EQ:
+                default:
+                  throw new Error("attribute invalid close char('/')");
+              }
+              break;
+            case "":
+              errorHandler.error("unexpected end of input");
+              if (s == S_TAG) {
+                el.setTagName(source.slice(start, p));
+              }
+              return p;
+            case ">":
+              switch (s) {
+                case S_TAG:
+                  el.setTagName(source.slice(start, p));
+                case S_ATTR_END:
+                case S_TAG_SPACE:
+                case S_TAG_CLOSE:
+                  break;
+                //normal
+                case S_ATTR_NOQUOT_VALUE:
+                //Compatible state
+                case S_ATTR:
+                  value = source.slice(start, p);
+                  if (value.slice(-1) === "/") {
+                    el.closed = true;
+                    value = value.slice(0, -1);
+                  }
+                case S_ATTR_SPACE:
+                  if (s === S_ATTR_SPACE) {
+                    value = attrName;
+                  }
+                  if (s == S_ATTR_NOQUOT_VALUE) {
+                    errorHandler.warning('attribute "' + value + '" missed quot(")!');
+                    addAttribute(attrName, value, start);
+                  } else {
+                    if (!NAMESPACE.isHTML(currentNSMap[""]) || !value.match(/^(?:disabled|checked|selected)$/i)) {
+                      errorHandler.warning('attribute "' + value + '" missed value!! "' + value + '" instead!!');
+                    }
+                    addAttribute(value, value, start);
+                  }
+                  break;
+                case S_EQ:
+                  throw new Error("attribute value missed!!");
+              }
+              return p;
+            /*xml space '\x20' | #x9 | #xD | #xA; */
+            case "\x80":
+              c = " ";
+            default:
+              if (c <= " ") {
+                switch (s) {
+                  case S_TAG:
+                    el.setTagName(source.slice(start, p));
+                    s = S_TAG_SPACE;
+                    break;
+                  case S_ATTR:
+                    attrName = source.slice(start, p);
+                    s = S_ATTR_SPACE;
+                    break;
+                  case S_ATTR_NOQUOT_VALUE:
+                    var value = source.slice(start, p);
+                    errorHandler.warning('attribute "' + value + '" missed quot(")!!');
+                    addAttribute(attrName, value, start);
+                  case S_ATTR_END:
+                    s = S_TAG_SPACE;
+                    break;
+                }
+              } else {
+                switch (s) {
+                  //case S_TAG:void();break;
+                  //case S_ATTR:void();break;
+                  //case S_ATTR_NOQUOT_VALUE:void();break;
+                  case S_ATTR_SPACE:
+                    var tagName = el.tagName;
+                    if (!NAMESPACE.isHTML(currentNSMap[""]) || !attrName.match(/^(?:disabled|checked|selected)$/i)) {
+                      errorHandler.warning('attribute "' + attrName + '" missed value!! "' + attrName + '" instead2!!');
+                    }
+                    addAttribute(attrName, attrName, start);
+                    start = p;
+                    s = S_ATTR;
+                    break;
+                  case S_ATTR_END:
+                    errorHandler.warning('attribute space is required"' + attrName + '"!!');
+                  case S_TAG_SPACE:
+                    s = S_ATTR;
+                    start = p;
+                    break;
+                  case S_EQ:
+                    s = S_ATTR_NOQUOT_VALUE;
+                    start = p;
+                    break;
+                  case S_TAG_CLOSE:
+                    throw new Error("elements closed character '/' and '>' must be connected to");
+                }
+              }
+          }
+          p++;
+        }
+      }
+      function appendElement(el, domBuilder, currentNSMap) {
+        var tagName = el.tagName;
+        var localNSMap = null;
+        var i = el.length;
+        while (i--) {
+          var a = el[i];
+          var qName = a.qName;
+          var value = a.value;
+          var nsp = qName.indexOf(":");
+          if (nsp > 0) {
+            var prefix = a.prefix = qName.slice(0, nsp);
+            var localName = qName.slice(nsp + 1);
+            var nsPrefix = prefix === "xmlns" && localName;
+          } else {
+            localName = qName;
+            prefix = null;
+            nsPrefix = qName === "xmlns" && "";
+          }
+          a.localName = localName;
+          if (nsPrefix !== false) {
+            if (localNSMap == null) {
+              localNSMap = {};
+              _copy(currentNSMap, currentNSMap = {});
+            }
+            currentNSMap[nsPrefix] = localNSMap[nsPrefix] = value;
+            a.uri = NAMESPACE.XMLNS;
+            domBuilder.startPrefixMapping(nsPrefix, value);
+          }
+        }
+        var i = el.length;
+        while (i--) {
+          a = el[i];
+          var prefix = a.prefix;
+          if (prefix) {
+            if (prefix === "xml") {
+              a.uri = NAMESPACE.XML;
+            }
+            if (prefix !== "xmlns") {
+              a.uri = currentNSMap[prefix || ""];
+            }
+          }
+        }
+        var nsp = tagName.indexOf(":");
+        if (nsp > 0) {
+          prefix = el.prefix = tagName.slice(0, nsp);
+          localName = el.localName = tagName.slice(nsp + 1);
+        } else {
+          prefix = null;
+          localName = el.localName = tagName;
+        }
+        var ns = el.uri = currentNSMap[prefix || ""];
+        domBuilder.startElement(ns, localName, tagName, el);
+        if (el.closed) {
+          domBuilder.endElement(ns, localName, tagName);
+          if (localNSMap) {
+            for (prefix in localNSMap) {
+              if (Object.prototype.hasOwnProperty.call(localNSMap, prefix)) {
+                domBuilder.endPrefixMapping(prefix);
+              }
+            }
+          }
+        } else {
+          el.currentNSMap = currentNSMap;
+          el.localNSMap = localNSMap;
+          return true;
+        }
+      }
+      function parseHtmlSpecialContent(source, elStartEnd, tagName, entityReplacer, domBuilder) {
+        if (/^(?:script|textarea)$/i.test(tagName)) {
+          var elEndStart = source.indexOf("</" + tagName + ">", elStartEnd);
+          var text = source.substring(elStartEnd + 1, elEndStart);
+          if (/[&<]/.test(text)) {
+            if (/^script$/i.test(tagName)) {
+              domBuilder.characters(text, 0, text.length);
+              return elEndStart;
+            }
+            text = text.replace(/&#?\w+;/g, entityReplacer);
+            domBuilder.characters(text, 0, text.length);
+            return elEndStart;
+          }
+        }
+        return elStartEnd + 1;
+      }
+      function fixSelfClosed(source, elStartEnd, tagName, closeMap) {
+        var pos = closeMap[tagName];
+        if (pos == null) {
+          pos = source.lastIndexOf("</" + tagName + ">");
+          if (pos < elStartEnd) {
+            pos = source.lastIndexOf("</" + tagName);
+          }
+          closeMap[tagName] = pos;
+        }
+        return pos < elStartEnd;
+      }
+      function _copy(source, target) {
+        for (var n in source) {
+          if (Object.prototype.hasOwnProperty.call(source, n)) {
+            target[n] = source[n];
+          }
+        }
+      }
+      function parseDCC(source, start, domBuilder, errorHandler) {
+        var next = source.charAt(start + 2);
+        switch (next) {
+          case "-":
+            if (source.charAt(start + 3) === "-") {
+              var end = source.indexOf("-->", start + 4);
+              if (end > start) {
+                domBuilder.comment(source, start + 4, end - start - 4);
+                return end + 3;
+              } else {
+                errorHandler.error("Unclosed comment");
+                return -1;
+              }
+            } else {
+              return -1;
+            }
+          default:
+            if (source.substr(start + 3, 6) == "CDATA[") {
+              var end = source.indexOf("]]>", start + 9);
+              domBuilder.startCDATA();
+              domBuilder.characters(source, start + 9, end - start - 9);
+              domBuilder.endCDATA();
+              return end + 3;
+            }
+            var matchs = split(source, start);
+            var len = matchs.length;
+            if (len > 1 && /!doctype/i.test(matchs[0][0])) {
+              var name = matchs[1][0];
+              var pubid = false;
+              var sysid = false;
+              if (len > 3) {
+                if (/^public$/i.test(matchs[2][0])) {
+                  pubid = matchs[3][0];
+                  sysid = len > 4 && matchs[4][0];
+                } else if (/^system$/i.test(matchs[2][0])) {
+                  sysid = matchs[3][0];
+                }
+              }
+              var lastMatch = matchs[len - 1];
+              domBuilder.startDTD(name, pubid, sysid);
+              domBuilder.endDTD();
+              return lastMatch.index + lastMatch[0].length;
+            }
+        }
+        return -1;
+      }
+      function parseInstruction(source, start, domBuilder) {
+        var end = source.indexOf("?>", start);
+        if (end) {
+          var match = source.substring(start, end).match(/^<\?(\S*)\s*([\s\S]*?)$/);
+          if (match) {
+            var len = match[0].length;
+            domBuilder.processingInstruction(match[1], match[2]);
+            return end + 2;
+          } else {
+            return -1;
+          }
+        }
+        return -1;
+      }
+      function ElementAttributes() {
+        this.attributeNames = {};
+      }
+      ElementAttributes.prototype = {
+        setTagName: function(tagName) {
+          if (!tagNamePattern.test(tagName)) {
+            throw new Error("invalid tagName:" + tagName);
+          }
+          this.tagName = tagName;
+        },
+        addValue: function(qName, value, offset) {
+          if (!tagNamePattern.test(qName)) {
+            throw new Error("invalid attribute:" + qName);
+          }
+          this.attributeNames[qName] = this.length;
+          this[this.length++] = { qName, value, offset };
+        },
+        length: 0,
+        getLocalName: function(i) {
+          return this[i].localName;
+        },
+        getLocator: function(i) {
+          return this[i].locator;
+        },
+        getQName: function(i) {
+          return this[i].qName;
+        },
+        getURI: function(i) {
+          return this[i].uri;
+        },
+        getValue: function(i) {
+          return this[i].value;
+        }
+        //	,getIndex:function(uri, localName)){
+        //		if(localName){
+        //
+        //		}else{
+        //			var qName = uri
+        //		}
+        //	},
+        //	getValue:function(){return this.getValue(this.getIndex.apply(this,arguments))},
+        //	getType:function(uri,localName){}
+        //	getType:function(i){},
+      };
+      function split(source, start) {
+        var match;
+        var buf = [];
+        var reg = /'[^']+'|"[^"]+"|[^\s<>\/=]+=?|(\/?\s*>|<)/g;
+        reg.lastIndex = start;
+        reg.exec(source);
+        while (match = reg.exec(source)) {
+          buf.push(match);
+          if (match[1]) return buf;
+        }
+      }
+      exports.XMLReader = XMLReader;
+      exports.ParseError = ParseError;
+    }
+  });
+
+  // node_modules/@xmldom/xmldom/lib/dom-parser.js
+  var require_dom_parser = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/dom-parser.js"(exports) {
+      var conventions = require_conventions();
+      var dom = require_dom();
+      var entities = require_entities();
+      var sax = require_sax();
+      var DOMImplementation = dom.DOMImplementation;
+      var NAMESPACE = conventions.NAMESPACE;
+      var ParseError = sax.ParseError;
+      var XMLReader = sax.XMLReader;
+      function normalizeLineEndings(input) {
+        return input.replace(/\r[\n\u0085]/g, "\n").replace(/[\r\u0085\u2028]/g, "\n");
+      }
+      function DOMParser2(options) {
+        this.options = options || { locator: {} };
+      }
+      DOMParser2.prototype.parseFromString = function(source, mimeType) {
+        var options = this.options;
+        var sax2 = new XMLReader();
+        var domBuilder = options.domBuilder || new DOMHandler();
+        var errorHandler = options.errorHandler;
+        var locator = options.locator;
+        var defaultNSMap = options.xmlns || {};
+        var isHTML = /\/x?html?$/.test(mimeType);
+        var entityMap = isHTML ? entities.HTML_ENTITIES : entities.XML_ENTITIES;
+        if (locator) {
+          domBuilder.setDocumentLocator(locator);
+        }
+        sax2.errorHandler = buildErrorHandler(errorHandler, domBuilder, locator);
+        sax2.domBuilder = options.domBuilder || domBuilder;
+        if (isHTML) {
+          defaultNSMap[""] = NAMESPACE.HTML;
+        }
+        defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML;
+        var normalize = options.normalizeLineEndings || normalizeLineEndings;
+        if (source && typeof source === "string") {
+          sax2.parse(
+            normalize(source),
+            defaultNSMap,
+            entityMap
+          );
+        } else {
+          sax2.errorHandler.error("invalid doc source");
+        }
+        return domBuilder.doc;
+      };
+      function buildErrorHandler(errorImpl, domBuilder, locator) {
+        if (!errorImpl) {
+          if (domBuilder instanceof DOMHandler) {
+            return domBuilder;
+          }
+          errorImpl = domBuilder;
+        }
+        var errorHandler = {};
+        var isCallback = errorImpl instanceof Function;
+        locator = locator || {};
+        function build(key) {
+          var fn = errorImpl[key];
+          if (!fn && isCallback) {
+            fn = errorImpl.length == 2 ? function(msg) {
+              errorImpl(key, msg);
+            } : errorImpl;
+          }
+          errorHandler[key] = fn && function(msg) {
+            fn("[xmldom " + key + "]	" + msg + _locator(locator));
+          } || function() {
+          };
+        }
+        build("warning");
+        build("error");
+        build("fatalError");
+        return errorHandler;
+      }
+      function DOMHandler() {
+        this.cdata = false;
+      }
+      function position(locator, node) {
+        node.lineNumber = locator.lineNumber;
+        node.columnNumber = locator.columnNumber;
+      }
+      DOMHandler.prototype = {
+        startDocument: function() {
+          this.doc = new DOMImplementation().createDocument(null, null, null);
+          if (this.locator) {
+            this.doc.documentURI = this.locator.systemId;
+          }
+        },
+        startElement: function(namespaceURI, localName, qName, attrs) {
+          var doc = this.doc;
+          var el = doc.createElementNS(namespaceURI, qName || localName);
+          var len = attrs.length;
+          appendElement(this, el);
+          this.currentElement = el;
+          this.locator && position(this.locator, el);
+          for (var i = 0; i < len; i++) {
+            var namespaceURI = attrs.getURI(i);
+            var value = attrs.getValue(i);
+            var qName = attrs.getQName(i);
+            var attr = doc.createAttributeNS(namespaceURI, qName);
+            this.locator && position(attrs.getLocator(i), attr);
+            attr.value = attr.nodeValue = value;
+            el.setAttributeNode(attr);
+          }
+        },
+        endElement: function(namespaceURI, localName, qName) {
+          var current = this.currentElement;
+          var tagName = current.tagName;
+          this.currentElement = current.parentNode;
+        },
+        startPrefixMapping: function(prefix, uri) {
+        },
+        endPrefixMapping: function(prefix) {
+        },
+        processingInstruction: function(target, data) {
+          var ins = this.doc.createProcessingInstruction(target, data);
+          this.locator && position(this.locator, ins);
+          appendElement(this, ins);
+        },
+        ignorableWhitespace: function(ch, start, length) {
+        },
+        characters: function(chars, start, length) {
+          chars = _toString.apply(this, arguments);
+          if (chars) {
+            if (this.cdata) {
+              var charNode = this.doc.createCDATASection(chars);
+            } else {
+              var charNode = this.doc.createTextNode(chars);
+            }
+            if (this.currentElement) {
+              this.currentElement.appendChild(charNode);
+            } else if (/^\s*$/.test(chars)) {
+              this.doc.appendChild(charNode);
+            }
+            this.locator && position(this.locator, charNode);
+          }
+        },
+        skippedEntity: function(name) {
+        },
+        endDocument: function() {
+          this.doc.normalize();
+        },
+        setDocumentLocator: function(locator) {
+          if (this.locator = locator) {
+            locator.lineNumber = 0;
+          }
+        },
+        //LexicalHandler
+        comment: function(chars, start, length) {
+          chars = _toString.apply(this, arguments);
+          var comm = this.doc.createComment(chars);
+          this.locator && position(this.locator, comm);
+          appendElement(this, comm);
+        },
+        startCDATA: function() {
+          this.cdata = true;
+        },
+        endCDATA: function() {
+          this.cdata = false;
+        },
+        startDTD: function(name, publicId, systemId) {
+          var impl = this.doc.implementation;
+          if (impl && impl.createDocumentType) {
+            var dt = impl.createDocumentType(name, publicId, systemId);
+            this.locator && position(this.locator, dt);
+            appendElement(this, dt);
+            this.doc.doctype = dt;
+          }
+        },
+        /**
+         * @see org.xml.sax.ErrorHandler
+         * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+         */
+        warning: function(error) {
+          console.warn("[xmldom warning]	" + error, _locator(this.locator));
+        },
+        error: function(error) {
+          console.error("[xmldom error]	" + error, _locator(this.locator));
+        },
+        fatalError: function(error) {
+          throw new ParseError(error, this.locator);
+        }
+      };
+      function _locator(l) {
+        if (l) {
+          return "\n@" + (l.systemId || "") + "#[line:" + l.lineNumber + ",col:" + l.columnNumber + "]";
+        }
+      }
+      function _toString(chars, start, length) {
+        if (typeof chars == "string") {
+          return chars.substr(start, length);
+        } else {
+          if (chars.length >= start + length || start) {
+            return new java.lang.String(chars, start, length) + "";
+          }
+          return chars;
+        }
+      }
+      "endDTD,startEntity,endEntity,attributeDecl,elementDecl,externalEntityDecl,internalEntityDecl,resolveEntity,getExternalSubset,notationDecl,unparsedEntityDecl".replace(/\w+/g, function(key) {
+        DOMHandler.prototype[key] = function() {
+          return null;
+        };
+      });
+      function appendElement(hander, node) {
+        if (!hander.currentElement) {
+          hander.doc.appendChild(node);
+        } else {
+          hander.currentElement.appendChild(node);
+        }
+      }
+      exports.__DOMHandler = DOMHandler;
+      exports.normalizeLineEndings = normalizeLineEndings;
+      exports.DOMParser = DOMParser2;
+    }
+  });
+
+  // node_modules/@xmldom/xmldom/lib/index.js
+  var require_lib = __commonJS({
+    "node_modules/@xmldom/xmldom/lib/index.js"(exports) {
+      var dom = require_dom();
+      exports.DOMImplementation = dom.DOMImplementation;
+      exports.XMLSerializer = dom.XMLSerializer;
+      exports.DOMParser = require_dom_parser().DOMParser;
+    }
+  });
+
+  // lib/parser.js
+  function multistatus(string) {
+    let parser = new DOMParser();
+    let doc = parser.parseFromString(string, "text/xml");
+    let result = traverse.multistatus(child(doc, "multistatus"));
+    debug(`input:
+${string}
+output:
+${JSON.stringify(result)}
+`);
+    return result;
+  }
+  function complex(node, childspec, collapse) {
+    let result = {};
+    for (let key in childspec) {
+      if (childspec[key]) {
+        result[key] = [];
+      }
+    }
+    childNodes(node).forEach(
+      (childNode) => traverseChild(node, childNode, childspec, result)
+    );
+    return maybeCollapse(result, childspec, collapse);
+  }
+  function traverseChild(node, childNode, childspec, result) {
+    if (childNode.nodeType === 3 && /^\s+$/.test(childNode.nodeValue)) {
+      return;
+    }
+    let localName = camelize(childNode.localName, "-");
+    if (!(localName in childspec)) {
+      debug("Unexpected node of type " + localName + " encountered while parsing " + node.localName + " node!");
+      let value = childNode.textContent;
+      if (localName in result) {
+        if (!Array.isArray(result[camelCase])) {
+          result[localName] = [result[localName]];
+        }
+        result[localName].push(value);
+        return;
+      }
+      result[localName] = value;
+      return;
+    }
+    let traversal = traverse[localName](childNode);
+    if (childspec[localName]) {
+      result[localName].push(traversal);
+    } else {
+      result[localName] = traversal;
+    }
+  }
+  function maybeCollapse(result, childspec, collapse) {
+    if (!collapse) {
+      return result;
+    }
+    if (!childspec[collapse]) {
+      return result[collapse];
+    }
+    return result[collapse].reduce((a, b) => a.concat(b), []);
+  }
+  function childNodes(node) {
+    let result = node.childNodes;
+    if (!Array.isArray(result)) {
+      result = Array.prototype.slice.call(result);
+    }
+    return result;
+  }
+  function children(node, localName) {
+    return childNodes(node).filter((childNode) => childNode.localName === localName);
+  }
+  function child(node, localName) {
+    return children(node, localName)[0];
+  }
+  var debug, DOMParser, traverse;
+  var init_parser = __esm({
+    "lib/parser.js"() {
+      init_camelize();
+      debug = require_debug()("dav:parser");
+      DOMParser = require_lib().DOMParser;
+      traverse = {
+        // { response: [x, y, z] }
+        multistatus: (node) => complex(node, { response: true }),
+        // { propstat: [x, y, z] }
+        response: (node) => complex(node, { propstat: true, href: false }),
+        // { prop: x }
+        propstat: (node) => complex(node, { prop: false }),
+        // {
+        //   resourcetype: x
+        //   supportedCalendarComponentSet: y,
+        //   supportedReportSet: z
+        // }
+        prop: (node) => {
+          return complex(node, {
+            resourcetype: false,
+            supportedCalendarComponentSet: false,
+            supportedReportSet: false,
+            currentUserPrincipal: false,
+            groups: false,
+            invite: false
+          });
+        },
+        resourcetype: (node) => {
+          return childNodes(node).map((childNode) => childNode.localName);
+        },
+        groups: (node) => complex(node, { group: true }, "group"),
+        group: (node) => {
+          return childNodes(node).map((childNode) => childNode.nodeValue);
+        },
+        invite: (node) => complex(node, { user: true }, "user"),
+        user: (node) => complex(node, { href: false, access: false }),
+        access: (node) => complex(node, {}),
+        //access: node => {
+        //  return childNodes(node).map(childNode => childNode.localName);
+        //},
+        // [x, y, z]
+        supportedCalendarComponentSet: (node) => complex(node, { comp: true }, "comp"),
+        // [x, y, z]
+        supportedReportSet: (node) => {
+          return complex(node, { supportedReport: true }, "supportedReport");
+        },
+        comp: (node) => node.getAttribute("name"),
+        // x
+        supportedReport: (node) => complex(node, { report: false }, "report"),
+        report: (node) => {
+          return childNodes(node).map((childNode) => childNode.localName);
+        },
+        href: (node) => {
+          return decodeURIComponent(childNodes(node)[0].nodeValue);
+        },
+        currentUserPrincipal: (node) => {
+          return complex(node, { href: false }, "href");
+        }
+      };
+    }
+  });
+
+  // lib/template/prop.js
+  function prop(item) {
+    if (!item.children || !item.children.length) {
+      if (typeof item.value === "undefined") {
+        return `<${xmlnsPrefix(item.namespace)}:${item.name} />`;
+      }
+      return `<${xmlnsPrefix(item.namespace)}:${item.name}>${item.value}</${xmlnsPrefix(item.namespace)}:${item.name}>`;
+    }
+    let children2 = item.children.map(prop);
+    return `<${xmlnsPrefix(item.namespace)}:${item.name}>
+            ${children2}
+          </${xmlnsPrefix(item.namespace)}:${item.name}>`;
+  }
+  function xmlnsPrefix(namespace) {
+    switch (namespace) {
+      case DAV:
+        return "d";
+      case CALENDAR_SERVER:
+        return "cs";
+      case CALDAV:
+        return "c";
+      case CARDDAV:
+        return "card";
+      case OC:
+        return "oc";
+      default:
+        throw new Error("Unrecognized xmlns " + namespace);
+    }
+  }
+  var init_prop = __esm({
+    "lib/template/prop.js"() {
+      init_namespace();
+    }
+  });
+
+  // lib/template/address_book_query.js
+  var address_book_query_exports = {};
+  __export(address_book_query_exports, {
+    default: () => addressBookQuery
+  });
+  function addressBookQuery(object) {
+    return `<card:addressbook-query xmlns:card="urn:ietf:params:xml:ns:carddav"
+                          xmlns:d="DAV:">
+    <d:prop>
+      ${object.props.map(prop)}
+    </d:prop>
+    <!-- According to http://stackoverflow.com/questions/23742568/google-carddav-api-addressbook-multiget-returns-400-bad-request,
+         Google's CardDAV server requires a filter element. I don't think all addressbook-query calls need a filter in the spec though? -->
+  </card:addressbook-query>`;
+  }
+  var init_address_book_query = __esm({
+    "lib/template/address_book_query.js"() {
+      init_prop();
+    }
+  });
+
+  // lib/template/filter.js
+  function filter(item) {
+    if (!item.children || !item.children.length) {
+      return `<c:${item.type} ${formatAttrs(item.attrs)}/>`;
+    }
+    let children2 = item.children.map(filter);
+    return `<c:${item.type} ${formatAttrs(item.attrs)}>
+            ${children2}
+          </c:${item.type}>`;
+  }
+  function formatAttrs(attrs) {
+    if (typeof attrs !== "object") {
+      return "";
+    }
+    return Object.keys(attrs).map((attr) => `${attr}="${attrs[attr]}"`).join(" ");
+  }
+  var init_filter = __esm({
+    "lib/template/filter.js"() {
+    }
+  });
+
+  // lib/template/calendar_query.js
+  var calendar_query_exports = {};
+  __export(calendar_query_exports, {
+    default: () => calendarQuery
+  });
+  function calendarQuery(object) {
+    return `<c:calendar-query xmlns:c="urn:ietf:params:xml:ns:caldav"
+                    xmlns:cs="http://calendarserver.org/ns/"
+                    xmlns:d="DAV:">
+    <d:prop>
+      ${object.props.map(prop)}
+    </d:prop>
+    <c:filter>
+      ${object.filters.map(filter)}
+    </c:filter>
+    ${object.timezone ? "<c:timezone>" + object.timezone + "</c:timezone>" : ""}
+  </c:calendar-query>`;
+  }
+  var init_calendar_query = __esm({
+    "lib/template/calendar_query.js"() {
+      init_filter();
+      init_prop();
+    }
+  });
+
+  // lib/template/propfind.js
+  var propfind_exports = {};
+  __export(propfind_exports, {
+    default: () => propfind
+  });
+  function propfind(object) {
+    return `<d:propfind xmlns:c="urn:ietf:params:xml:ns:caldav"
+              xmlns:card="urn:ietf:params:xml:ns:carddav"
+              xmlns:cs="http://calendarserver.org/ns/"
+              xmlns:oc="http://owncloud.org/ns"
+              xmlns:d="DAV:">
+    <d:prop>
+      ${object.props.map(prop)}
+    </d:prop>
+  </d:propfind>`;
+  }
+  var init_propfind = __esm({
+    "lib/template/propfind.js"() {
+      init_prop();
+    }
+  });
+
+  // lib/template/sync_collection.js
+  var sync_collection_exports = {};
+  __export(sync_collection_exports, {
+    default: () => syncCollection
+  });
+  function syncCollection(object) {
+    return `<d:sync-collection xmlns:c="urn:ietf:params:xml:ns:caldav"
+                     xmlns:card="urn:ietf:params:xml:ns:carddav"
+                     xmlns:d="DAV:">
+    <d:sync-level>${object.syncLevel}</d:sync-level>
+    <d:sync-token>${object.syncToken}</d:sync-token>
+    <d:prop>
+      ${object.props.map(prop)}
+    </d:prop>
+  </d:sync-collection>`;
+  }
+  var init_sync_collection = __esm({
+    "lib/template/sync_collection.js"() {
+      init_prop();
+    }
+  });
+
+  // lib/template/mkcol.js
+  var mkcol_exports = {};
+  __export(mkcol_exports, {
+    default: () => mkcol
+  });
+  function mkcol(object) {
+    return `<d:mkcol xmlns:c="urn:ietf:params:xml:ns:caldav"
+              xmlns:card="urn:ietf:params:xml:ns:carddav"
+              xmlns:cs="http://calendarserver.org/ns/"
+              xmlns:d="DAV:">
+    <d:set>
+      <d:prop>
+        ${object.props.map(prop)}
+      </d:prop>
+    </d:set>
+  </d:mkcol>`;
+  }
+  var init_mkcol = __esm({
+    "lib/template/mkcol.js"() {
+      init_prop();
+    }
+  });
+
+  // lib/template/proppatch.js
+  var proppatch_exports = {};
+  __export(proppatch_exports, {
+    default: () => proppatch
+  });
+  function proppatch(object) {
+    return `<d:propertyupdate xmlns:c="urn:ietf:params:xml:ns:caldav"
+              xmlns:card="urn:ietf:params:xml:ns:carddav"
+              xmlns:cs="http://calendarserver.org/ns/"
+              xmlns:d="DAV:">
+    <d:set>
+      <d:prop>
+        ${object.props.map(prop)}
+      </d:prop>
+    </d:set>
+  </d:propertyupdate>`;
+  }
+  var init_proppatch = __esm({
+    "lib/template/proppatch.js"() {
+      init_prop();
+    }
+  });
+
+  // lib/template/index.js
+  var require_template = __commonJS({
+    "lib/template/index.js"(exports) {
+      exports.addressBookQuery = (init_address_book_query(), __toCommonJS(address_book_query_exports));
+      exports.calendarQuery = (init_calendar_query(), __toCommonJS(calendar_query_exports));
+      exports.propfind = (init_propfind(), __toCommonJS(propfind_exports));
+      exports.syncCollection = (init_sync_collection(), __toCommonJS(sync_collection_exports));
+      exports.mkcol = (init_mkcol(), __toCommonJS(mkcol_exports));
+      exports.proppatch = (init_proppatch(), __toCommonJS(proppatch_exports));
+    }
+  });
+
+  // lib/request.js
+  var request_exports = {};
+  __export(request_exports, {
+    Request: () => Request,
+    addressBookQuery: () => addressBookQuery3,
+    basic: () => basic,
+    calendarQuery: () => calendarQuery3,
+    collectionQuery: () => collectionQuery,
+    getProps: () => getProps,
+    mergeProps: () => mergeProps,
+    mkcol: () => mkcol3,
+    propfind: () => propfind3,
+    proppatch: () => proppatch3,
+    setRequestHeaders: () => setRequestHeaders,
+    syncCollection: () => syncCollection3
+  });
+  function addressBookQuery3(options) {
+    return collectionQuery(
+      template.addressBookQuery({ props: options.props || [] }),
+      { depth: options.depth }
+    );
+  }
+  function basic(options) {
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    return new Request({
+      method: options.method,
+      requestData: options.data,
+      transformRequest
+    });
+  }
+  function calendarQuery3(options) {
+    return collectionQuery(
+      template.calendarQuery({
+        props: options.props || [],
+        filters: options.filters || [],
+        timezone: options.timezone
+      }),
+      {
+        depth: options.depth
+      }
+    );
+  }
+  function collectionQuery(requestData, options) {
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    function transformResponse(xhr) {
+      return multistatus(xhr.responseText).response.map((res) => {
+        return { href: res.href, props: getProps(res.propstat) };
+      });
+    }
+    return new Request({
+      method: "REPORT",
+      requestData,
+      transformRequest,
+      transformResponse
+    });
+  }
+  function mkcol3(options) {
+    let requestData = template.mkcol({ props: options.props });
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    return new Request({
+      method: "MKCOL",
+      requestData,
+      transformRequest
+    });
+  }
+  function proppatch3(options) {
+    let requestData = template.proppatch({ props: options.props });
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    return new Request({
+      method: "PROPPATCH",
+      requestData,
+      transformRequest
+    });
+  }
+  function propfind3(options) {
+    let requestData = template.propfind({ props: options.props });
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    function transformResponse(xhr) {
+      let responses = multistatus(xhr.responseText).response.map((res) => {
+        return { href: res.href, props: getProps(res.propstat) };
+      });
+      if (!options.mergeResponses) {
+        return responses;
+      }
+      let merged = mergeProps(responses.map((res) => res.props));
+      let hrefs = responses.map((res) => res.href);
+      return { props: merged, hrefs };
+    }
+    return new Request({
+      method: "PROPFIND",
+      requestData,
+      transformRequest,
+      transformResponse
+    });
+  }
+  function syncCollection3(options) {
+    let requestData = template.syncCollection({
+      props: options.props,
+      syncLevel: options.syncLevel,
+      syncToken: options.syncToken
+    });
+    function transformRequest(xhr) {
+      setRequestHeaders(xhr, options);
+    }
+    function transformResponse(xhr) {
+      let object = multistatus(xhr.responseText);
+      let responses = object.response.map((res) => {
+        return { href: res.href, props: getProps(res.propstat) };
+      });
+      return { responses, syncToken: object.syncToken };
+    }
+    return new Request({
+      method: "REPORT",
+      requestData,
+      transformRequest,
+      transformResponse
+    });
+  }
+  function getProp(propstat) {
+    if (/404/g.test(propstat.status)) {
+      return null;
+    }
+    if (/5\d{2}/g.test(propstat.status) || /4\d{2}/g.test(propstat.status)) {
+      throw new Error("Bad status on propstat: " + propstat.status);
+    }
+    return "prop" in propstat ? propstat.prop : null;
+  }
+  function mergeProps(props) {
+    return props.reduce((a, b) => Object.assign(a, b), {});
+  }
+  function getProps(propstats) {
+    return mergeProps(
+      propstats.map(getProp).filter((prop2) => prop2 && typeof prop2 === "object")
+    );
+  }
+  function setRequestHeaders(request, options) {
+    if ("contentType" in options) {
+      request.setRequestHeader("Content-Type", options.contentType);
+    } else {
+      request.setRequestHeader("Content-Type", "application/xml;charset=utf-8");
+    }
+    if ("depth" in options) {
+      request.setRequestHeader("Depth", options.depth);
+    }
+    if ("etag" in options) {
+      request.setRequestHeader("If-Match", options.etag);
+    }
+    if ("destination" in options) {
+      request.setRequestHeader("Destination", options.destination);
+    }
+    if ("overwrite" in options) {
+      request.setRequestHeader("Overwrite", options.overwrite);
+    }
+  }
+  var template, Request;
+  var init_request = __esm({
+    "lib/request.js"() {
+      init_parser();
+      template = __toESM(require_template());
+      Request = class {
+        constructor(options = {}) {
+          Object.assign(this, {
+            method: null,
+            requestData: null,
+            transformRequest: null,
+            transformResponse: null,
+            onerror: null
+          }, options);
+        }
+      };
+    }
+  });
+
+  // node_modules/co/index.js
+  var require_co = __commonJS({
+    "node_modules/co/index.js"(exports, module) {
+      var slice = Array.prototype.slice;
+      module.exports = co5["default"] = co5.co = co5;
+      co5.wrap = function(fn) {
+        createPromise.__generatorFunction__ = fn;
+        return createPromise;
+        function createPromise() {
+          return co5.call(this, fn.apply(this, arguments));
+        }
+      };
+      function co5(gen) {
+        var ctx = this;
+        var args = slice.call(arguments, 1);
+        return new Promise(function(resolve, reject) {
+          if (typeof gen === "function") gen = gen.apply(ctx, args);
+          if (!gen || typeof gen.next !== "function") return resolve(gen);
+          onFulfilled();
+          function onFulfilled(res) {
+            var ret;
+            try {
+              ret = gen.next(res);
+            } catch (e) {
+              return reject(e);
+            }
+            next(ret);
+          }
+          function onRejected(err) {
+            var ret;
+            try {
+              ret = gen.throw(err);
+            } catch (e) {
+              return reject(e);
+            }
+            next(ret);
+          }
+          function next(ret) {
+            if (ret.done) return resolve(ret.value);
+            var value = toPromise.call(ctx, ret.value);
+            if (value && isPromise(value)) return value.then(onFulfilled, onRejected);
+            return onRejected(new TypeError('You may only yield a function, promise, generator, array, or object, but the following object was passed: "' + String(ret.value) + '"'));
+          }
+        });
+      }
+      function toPromise(obj) {
+        if (!obj) return obj;
+        if (isPromise(obj)) return obj;
+        if (isGeneratorFunction(obj) || isGenerator(obj)) return co5.call(this, obj);
+        if ("function" == typeof obj) return thunkToPromise.call(this, obj);
+        if (Array.isArray(obj)) return arrayToPromise.call(this, obj);
+        if (isObject(obj)) return objectToPromise.call(this, obj);
+        return obj;
+      }
+      function thunkToPromise(fn) {
+        var ctx = this;
+        return new Promise(function(resolve, reject) {
+          fn.call(ctx, function(err, res) {
+            if (err) return reject(err);
+            if (arguments.length > 2) res = slice.call(arguments, 1);
+            resolve(res);
+          });
+        });
+      }
+      function arrayToPromise(obj) {
+        return Promise.all(obj.map(toPromise, this));
+      }
+      function objectToPromise(obj) {
+        var results = new obj.constructor();
+        var keys = Object.keys(obj);
+        var promises = [];
+        for (var i = 0; i < keys.length; i++) {
+          var key = keys[i];
+          var promise = toPromise.call(this, obj[key]);
+          if (promise && isPromise(promise)) defer(promise, key);
+          else results[key] = obj[key];
+        }
+        return Promise.all(promises).then(function() {
+          return results;
+        });
+        function defer(promise2, key2) {
+          results[key2] = void 0;
+          promises.push(promise2.then(function(res) {
+            results[key2] = res;
+          }));
+        }
+      }
+      function isPromise(obj) {
+        return "function" == typeof obj.then;
+      }
+      function isGenerator(obj) {
+        return "function" == typeof obj.next && "function" == typeof obj.throw;
+      }
+      function isGeneratorFunction(obj) {
+        var constructor = obj.constructor;
+        if (!constructor) return false;
+        if ("GeneratorFunction" === constructor.name || "GeneratorFunction" === constructor.displayName) return true;
+        return isGenerator(constructor.prototype);
+      }
+      function isObject(val) {
+        return Object == val.constructor;
+      }
+    }
+  });
+
+  // node_modules/querystring/decode.js
+  var require_decode = __commonJS({
+    "node_modules/querystring/decode.js"(exports, module) {
+      "use strict";
+      function hasOwnProperty(obj, prop2) {
+        return Object.prototype.hasOwnProperty.call(obj, prop2);
+      }
+      module.exports = function(qs, sep, eq, options) {
+        sep = sep || "&";
+        eq = eq || "=";
+        var obj = {};
+        if (typeof qs !== "string" || qs.length === 0) {
+          return obj;
+        }
+        var regexp = /\+/g;
+        qs = qs.split(sep);
+        var maxKeys = 1e3;
+        if (options && typeof options.maxKeys === "number") {
+          maxKeys = options.maxKeys;
+        }
+        var len = qs.length;
+        if (maxKeys > 0 && len > maxKeys) {
+          len = maxKeys;
+        }
+        for (var i = 0; i < len; ++i) {
+          var x = qs[i].replace(regexp, "%20"), idx = x.indexOf(eq), kstr, vstr, k, v;
+          if (idx >= 0) {
+            kstr = x.substr(0, idx);
+            vstr = x.substr(idx + 1);
+          } else {
+            kstr = x;
+            vstr = "";
+          }
+          k = decodeURIComponent(kstr);
+          v = decodeURIComponent(vstr);
+          if (!hasOwnProperty(obj, k)) {
+            obj[k] = v;
+          } else if (Array.isArray(obj[k])) {
+            obj[k].push(v);
+          } else {
+            obj[k] = [obj[k], v];
+          }
+        }
+        return obj;
+      };
+    }
+  });
+
+  // node_modules/querystring/encode.js
+  var require_encode = __commonJS({
+    "node_modules/querystring/encode.js"(exports, module) {
+      "use strict";
+      var stringifyPrimitive = function(v) {
+        switch (typeof v) {
+          case "string":
+            return v;
+          case "boolean":
+            return v ? "true" : "false";
+          case "number":
+            return isFinite(v) ? v : "";
+          default:
+            return "";
+        }
+      };
+      module.exports = function(obj, sep, eq, name) {
+        sep = sep || "&";
+        eq = eq || "=";
+        if (obj === null) {
+          obj = void 0;
+        }
+        if (typeof obj === "object") {
+          return Object.keys(obj).map(function(k) {
+            var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
+            if (Array.isArray(obj[k])) {
+              return obj[k].map(function(v) {
+                return ks + encodeURIComponent(stringifyPrimitive(v));
+              }).join(sep);
+            } else {
+              return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
+            }
+          }).join(sep);
+        }
+        if (!name) return "";
+        return encodeURIComponent(stringifyPrimitive(name)) + eq + encodeURIComponent(stringifyPrimitive(obj));
+      };
+    }
+  });
+
+  // node_modules/querystring/index.js
+  var require_querystring = __commonJS({
+    "node_modules/querystring/index.js"(exports) {
+      "use strict";
+      exports.decode = exports.parse = require_decode();
+      exports.encode = exports.stringify = require_encode();
+    }
+  });
+
+  // ../../../shims/xmlhttprequest.js
+  var require_xmlhttprequest = __commonJS({
+    "../../../shims/xmlhttprequest.js"(exports, module) {
+      module.exports = { XMLHttpRequest: typeof self !== "undefined" && self.XMLHttpRequest };
+    }
+  });
+
+  // node_modules/url/node_modules/punycode/punycode.js
+  var require_punycode = __commonJS({
+    "node_modules/url/node_modules/punycode/punycode.js"(exports, module) {
+      (function(root) {
+        var freeExports = typeof exports == "object" && exports && !exports.nodeType && exports;
+        var freeModule = typeof module == "object" && module && !module.nodeType && module;
+        var freeGlobal = typeof global == "object" && global;
+        if (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal || freeGlobal.self === freeGlobal) {
+          root = freeGlobal;
+        }
+        var punycode, maxInt = 2147483647, base = 36, tMin = 1, tMax = 26, skew = 38, damp = 700, initialBias = 72, initialN = 128, delimiter = "-", regexPunycode = /^xn--/, regexNonASCII = /[^\x20-\x7E]/, regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g, errors = {
+          "overflow": "Overflow: input needs wider integers to process",
+          "not-basic": "Illegal input >= 0x80 (not a basic code point)",
+          "invalid-input": "Invalid input"
+        }, baseMinusTMin = base - tMin, floor = Math.floor, stringFromCharCode = String.fromCharCode, key;
+        function error(type) {
+          throw RangeError(errors[type]);
+        }
+        function map(array, fn) {
+          var length = array.length;
+          var result = [];
+          while (length--) {
+            result[length] = fn(array[length]);
+          }
+          return result;
+        }
+        function mapDomain(string, fn) {
+          var parts = string.split("@");
+          var result = "";
+          if (parts.length > 1) {
+            result = parts[0] + "@";
+            string = parts[1];
+          }
+          string = string.replace(regexSeparators, ".");
+          var labels = string.split(".");
+          var encoded = map(labels, fn).join(".");
+          return result + encoded;
+        }
+        function ucs2decode(string) {
+          var output = [], counter = 0, length = string.length, value, extra;
+          while (counter < length) {
+            value = string.charCodeAt(counter++);
+            if (value >= 55296 && value <= 56319 && counter < length) {
+              extra = string.charCodeAt(counter++);
+              if ((extra & 64512) == 56320) {
+                output.push(((value & 1023) << 10) + (extra & 1023) + 65536);
+              } else {
+                output.push(value);
+                counter--;
+              }
+            } else {
+              output.push(value);
+            }
+          }
+          return output;
+        }
+        function ucs2encode(array) {
+          return map(array, function(value) {
+            var output = "";
+            if (value > 65535) {
+              value -= 65536;
+              output += stringFromCharCode(value >>> 10 & 1023 | 55296);
+              value = 56320 | value & 1023;
+            }
+            output += stringFromCharCode(value);
+            return output;
+          }).join("");
+        }
+        function basicToDigit(codePoint) {
+          if (codePoint - 48 < 10) {
+            return codePoint - 22;
+          }
+          if (codePoint - 65 < 26) {
+            return codePoint - 65;
+          }
+          if (codePoint - 97 < 26) {
+            return codePoint - 97;
+          }
+          return base;
+        }
+        function digitToBasic(digit, flag) {
+          return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
+        }
+        function adapt(delta, numPoints, firstTime) {
+          var k = 0;
+          delta = firstTime ? floor(delta / damp) : delta >> 1;
+          delta += floor(delta / numPoints);
+          for (; delta > baseMinusTMin * tMax >> 1; k += base) {
+            delta = floor(delta / baseMinusTMin);
+          }
+          return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
+        }
+        function decode(input) {
+          var output = [], inputLength = input.length, out, i = 0, n = initialN, bias = initialBias, basic2, j, index, oldi, w, k, digit, t, baseMinusT;
+          basic2 = input.lastIndexOf(delimiter);
+          if (basic2 < 0) {
+            basic2 = 0;
+          }
+          for (j = 0; j < basic2; ++j) {
+            if (input.charCodeAt(j) >= 128) {
+              error("not-basic");
+            }
+            output.push(input.charCodeAt(j));
+          }
+          for (index = basic2 > 0 ? basic2 + 1 : 0; index < inputLength; ) {
+            for (oldi = i, w = 1, k = base; ; k += base) {
+              if (index >= inputLength) {
+                error("invalid-input");
+              }
+              digit = basicToDigit(input.charCodeAt(index++));
+              if (digit >= base || digit > floor((maxInt - i) / w)) {
+                error("overflow");
+              }
+              i += digit * w;
+              t = k <= bias ? tMin : k >= bias + tMax ? tMax : k - bias;
+              if (digit < t) {
+                break;
+              }
+              baseMinusT = base - t;
+              if (w > floor(maxInt / baseMinusT)) {
+                error("overflow");
+              }
+              w *= baseMinusT;
+            }
+            out = output.length + 1;
+            bias = adapt(i - oldi, out, oldi == 0);
+            if (floor(i / out) > maxInt - n) {
+              error("overflow");
+            }
+            n += floor(i / out);
+            i %= out;
+            output.splice(i++, 0, n);
+          }
+          return ucs2encode(output);
+        }
+        function encode(input) {
+          var n, delta, handledCPCount, basicLength, bias, j, m, q, k, t, currentValue, output = [], inputLength, handledCPCountPlusOne, baseMinusT, qMinusT;
+          input = ucs2decode(input);
+          inputLength = input.length;
+          n = initialN;
+          delta = 0;
+          bias = initialBias;
+          for (j = 0; j < inputLength; ++j) {
+            currentValue = input[j];
+            if (currentValue < 128) {
+              output.push(stringFromCharCode(currentValue));
+            }
+          }
+          handledCPCount = basicLength = output.length;
+          if (basicLength) {
+            output.push(delimiter);
+          }
+          while (handledCPCount < inputLength) {
+            for (m = maxInt, j = 0; j < inputLength; ++j) {
+              currentValue = input[j];
+              if (currentValue >= n && currentValue < m) {
+                m = currentValue;
+              }
+            }
+            handledCPCountPlusOne = handledCPCount + 1;
+            if (m - n > floor((maxInt - delta) / handledCPCountPlusOne)) {
+              error("overflow");
+            }
+            delta += (m - n) * handledCPCountPlusOne;
+            n = m;
+            for (j = 0; j < inputLength; ++j) {
+              currentValue = input[j];
+              if (currentValue < n && ++delta > maxInt) {
+                error("overflow");
+              }
+              if (currentValue == n) {
+                for (q = delta, k = base; ; k += base) {
+                  t = k <= bias ? tMin : k >= bias + tMax ? tMax : k - bias;
+                  if (q < t) {
+                    break;
+                  }
+                  qMinusT = q - t;
+                  baseMinusT = base - t;
+                  output.push(
+                    stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0))
+                  );
+                  q = floor(qMinusT / baseMinusT);
+                }
+                output.push(stringFromCharCode(digitToBasic(q, 0)));
+                bias = adapt(delta, handledCPCountPlusOne, handledCPCount == basicLength);
+                delta = 0;
+                ++handledCPCount;
+              }
+            }
+            ++delta;
+            ++n;
+          }
+          return output.join("");
+        }
+        function toUnicode(input) {
+          return mapDomain(input, function(string) {
+            return regexPunycode.test(string) ? decode(string.slice(4).toLowerCase()) : string;
+          });
+        }
+        function toASCII(input) {
+          return mapDomain(input, function(string) {
+            return regexNonASCII.test(string) ? "xn--" + encode(string) : string;
+          });
+        }
+        punycode = {
+          /**
+           * A string representing the current Punycode.js version number.
+           * @memberOf punycode
+           * @type String
+           */
+          "version": "1.3.2",
+          /**
+           * An object of methods to convert from JavaScript's internal character
+           * representation (UCS-2) to Unicode code points, and back.
+           * @see <https://mathiasbynens.be/notes/javascript-encoding>
+           * @memberOf punycode
+           * @type Object
+           */
+          "ucs2": {
+            "decode": ucs2decode,
+            "encode": ucs2encode
+          },
+          "decode": decode,
+          "encode": encode,
+          "toASCII": toASCII,
+          "toUnicode": toUnicode
+        };
+        if (typeof define == "function" && typeof define.amd == "object" && define.amd) {
+          define("punycode", function() {
+            return punycode;
+          });
+        } else if (freeExports && freeModule) {
+          if (module.exports == freeExports) {
+            freeModule.exports = punycode;
+          } else {
+            for (key in punycode) {
+              punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
+            }
+          }
+        } else {
+          root.punycode = punycode;
+        }
+      })(exports);
+    }
+  });
+
+  // node_modules/url/url.js
+  var require_url = __commonJS({
+    "node_modules/url/url.js"(exports) {
+      var punycode = require_punycode();
+      exports.parse = urlParse;
+      exports.resolve = urlResolve;
+      exports.resolveObject = urlResolveObject;
+      exports.format = urlFormat;
+      exports.Url = Url;
+      function Url() {
+        this.protocol = null;
+        this.slashes = null;
+        this.auth = null;
+        this.host = null;
+        this.port = null;
+        this.hostname = null;
+        this.hash = null;
+        this.search = null;
+        this.query = null;
+        this.pathname = null;
+        this.path = null;
+        this.href = null;
+      }
+      var protocolPattern = /^([a-z0-9.+-]+:)/i;
+      var portPattern = /:[0-9]*$/;
+      var delims = ["<", ">", '"', "`", " ", "\r", "\n", "	"];
+      var unwise = ["{", "}", "|", "\\", "^", "`"].concat(delims);
+      var autoEscape = ["'"].concat(unwise);
+      var nonHostChars = ["%", "/", "?", ";", "#"].concat(autoEscape);
+      var hostEndingChars = ["/", "?", "#"];
+      var hostnameMaxLen = 255;
+      var hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/;
+      var hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/;
+      var unsafeProtocol = {
+        "javascript": true,
+        "javascript:": true
+      };
+      var hostlessProtocol = {
+        "javascript": true,
+        "javascript:": true
+      };
+      var slashedProtocol = {
+        "http": true,
+        "https": true,
+        "ftp": true,
+        "gopher": true,
+        "file": true,
+        "http:": true,
+        "https:": true,
+        "ftp:": true,
+        "gopher:": true,
+        "file:": true
+      };
+      var querystring2 = require_querystring();
+      function urlParse(url4, parseQueryString, slashesDenoteHost) {
+        if (url4 && isObject(url4) && url4 instanceof Url) return url4;
+        var u = new Url();
+        u.parse(url4, parseQueryString, slashesDenoteHost);
+        return u;
+      }
+      Url.prototype.parse = function(url4, parseQueryString, slashesDenoteHost) {
+        if (!isString(url4)) {
+          throw new TypeError("Parameter 'url' must be a string, not " + typeof url4);
+        }
+        var rest = url4;
+        rest = rest.trim();
+        var proto = protocolPattern.exec(rest);
+        if (proto) {
+          proto = proto[0];
+          var lowerProto = proto.toLowerCase();
+          this.protocol = lowerProto;
+          rest = rest.substr(proto.length);
+        }
+        if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
+          var slashes = rest.substr(0, 2) === "//";
+          if (slashes && !(proto && hostlessProtocol[proto])) {
+            rest = rest.substr(2);
+            this.slashes = true;
+          }
+        }
+        if (!hostlessProtocol[proto] && (slashes || proto && !slashedProtocol[proto])) {
+          var hostEnd = -1;
+          for (var i = 0; i < hostEndingChars.length; i++) {
+            var hec = rest.indexOf(hostEndingChars[i]);
+            if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
+              hostEnd = hec;
+          }
+          var auth, atSign;
+          if (hostEnd === -1) {
+            atSign = rest.lastIndexOf("@");
+          } else {
+            atSign = rest.lastIndexOf("@", hostEnd);
+          }
+          if (atSign !== -1) {
+            auth = rest.slice(0, atSign);
+            rest = rest.slice(atSign + 1);
+            this.auth = decodeURIComponent(auth);
+          }
+          hostEnd = -1;
+          for (var i = 0; i < nonHostChars.length; i++) {
+            var hec = rest.indexOf(nonHostChars[i]);
+            if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
+              hostEnd = hec;
+          }
+          if (hostEnd === -1)
+            hostEnd = rest.length;
+          this.host = rest.slice(0, hostEnd);
+          rest = rest.slice(hostEnd);
+          this.parseHost();
+          this.hostname = this.hostname || "";
+          var ipv6Hostname = this.hostname[0] === "[" && this.hostname[this.hostname.length - 1] === "]";
+          if (!ipv6Hostname) {
+            var hostparts = this.hostname.split(/\./);
+            for (var i = 0, l = hostparts.length; i < l; i++) {
+              var part = hostparts[i];
+              if (!part) continue;
+              if (!part.match(hostnamePartPattern)) {
+                var newpart = "";
+                for (var j = 0, k = part.length; j < k; j++) {
+                  if (part.charCodeAt(j) > 127) {
+                    newpart += "x";
+                  } else {
+                    newpart += part[j];
+                  }
+                }
+                if (!newpart.match(hostnamePartPattern)) {
+                  var validParts = hostparts.slice(0, i);
+                  var notHost = hostparts.slice(i + 1);
+                  var bit = part.match(hostnamePartStart);
+                  if (bit) {
+                    validParts.push(bit[1]);
+                    notHost.unshift(bit[2]);
+                  }
+                  if (notHost.length) {
+                    rest = "/" + notHost.join(".") + rest;
+                  }
+                  this.hostname = validParts.join(".");
+                  break;
+                }
+              }
+            }
+          }
+          if (this.hostname.length > hostnameMaxLen) {
+            this.hostname = "";
+          } else {
+            this.hostname = this.hostname.toLowerCase();
+          }
+          if (!ipv6Hostname) {
+            var domainArray = this.hostname.split(".");
+            var newOut = [];
+            for (var i = 0; i < domainArray.length; ++i) {
+              var s = domainArray[i];
+              newOut.push(s.match(/[^A-Za-z0-9_-]/) ? "xn--" + punycode.encode(s) : s);
+            }
+            this.hostname = newOut.join(".");
+          }
+          var p = this.port ? ":" + this.port : "";
+          var h = this.hostname || "";
+          this.host = h + p;
+          this.href += this.host;
+          if (ipv6Hostname) {
+            this.hostname = this.hostname.substr(1, this.hostname.length - 2);
+            if (rest[0] !== "/") {
+              rest = "/" + rest;
+            }
+          }
+        }
+        if (!unsafeProtocol[lowerProto]) {
+          for (var i = 0, l = autoEscape.length; i < l; i++) {
+            var ae = autoEscape[i];
+            var esc = encodeURIComponent(ae);
+            if (esc === ae) {
+              esc = escape(ae);
+            }
+            rest = rest.split(ae).join(esc);
+          }
+        }
+        var hash = rest.indexOf("#");
+        if (hash !== -1) {
+          this.hash = rest.substr(hash);
+          rest = rest.slice(0, hash);
+        }
+        var qm = rest.indexOf("?");
+        if (qm !== -1) {
+          this.search = rest.substr(qm);
+          this.query = rest.substr(qm + 1);
+          if (parseQueryString) {
+            this.query = querystring2.parse(this.query);
+          }
+          rest = rest.slice(0, qm);
+        } else if (parseQueryString) {
+          this.search = "";
+          this.query = {};
+        }
+        if (rest) this.pathname = rest;
+        if (slashedProtocol[lowerProto] && this.hostname && !this.pathname) {
+          this.pathname = "/";
+        }
+        if (this.pathname || this.search) {
+          var p = this.pathname || "";
+          var s = this.search || "";
+          this.path = p + s;
+        }
+        this.href = this.format();
+        return this;
+      };
+      function urlFormat(obj) {
+        if (isString(obj)) obj = urlParse(obj);
+        if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
+        return obj.format();
+      }
+      Url.prototype.format = function() {
+        var auth = this.auth || "";
+        if (auth) {
+          auth = encodeURIComponent(auth);
+          auth = auth.replace(/%3A/i, ":");
+          auth += "@";
+        }
+        var protocol = this.protocol || "", pathname = this.pathname || "", hash = this.hash || "", host = false, query = "";
+        if (this.host) {
+          host = auth + this.host;
+        } else if (this.hostname) {
+          host = auth + (this.hostname.indexOf(":") === -1 ? this.hostname : "[" + this.hostname + "]");
+          if (this.port) {
+            host += ":" + this.port;
+          }
+        }
+        if (this.query && isObject(this.query) && Object.keys(this.query).length) {
+          query = querystring2.stringify(this.query);
+        }
+        var search = this.search || query && "?" + query || "";
+        if (protocol && protocol.substr(-1) !== ":") protocol += ":";
+        if (this.slashes || (!protocol || slashedProtocol[protocol]) && host !== false) {
+          host = "//" + (host || "");
+          if (pathname && pathname.charAt(0) !== "/") pathname = "/" + pathname;
+        } else if (!host) {
+          host = "";
+        }
+        if (hash && hash.charAt(0) !== "#") hash = "#" + hash;
+        if (search && search.charAt(0) !== "?") search = "?" + search;
+        pathname = pathname.replace(/[?#]/g, function(match) {
+          return encodeURIComponent(match);
+        });
+        search = search.replace("#", "%23");
+        return protocol + host + pathname + search + hash;
+      };
+      function urlResolve(source, relative) {
+        return urlParse(source, false, true).resolve(relative);
+      }
+      Url.prototype.resolve = function(relative) {
+        return this.resolveObject(urlParse(relative, false, true)).format();
+      };
+      function urlResolveObject(source, relative) {
+        if (!source) return relative;
+        return urlParse(source, false, true).resolveObject(relative);
+      }
+      Url.prototype.resolveObject = function(relative) {
+        if (isString(relative)) {
+          var rel = new Url();
+          rel.parse(relative, false, true);
+          relative = rel;
+        }
+        var result = new Url();
+        Object.keys(this).forEach(function(k) {
+          result[k] = this[k];
+        }, this);
+        result.hash = relative.hash;
+        if (relative.href === "") {
+          result.href = result.format();
+          return result;
+        }
+        if (relative.slashes && !relative.protocol) {
+          Object.keys(relative).forEach(function(k) {
+            if (k !== "protocol")
+              result[k] = relative[k];
+          });
+          if (slashedProtocol[result.protocol] && result.hostname && !result.pathname) {
+            result.path = result.pathname = "/";
+          }
+          result.href = result.format();
+          return result;
+        }
+        if (relative.protocol && relative.protocol !== result.protocol) {
+          if (!slashedProtocol[relative.protocol]) {
+            Object.keys(relative).forEach(function(k) {
+              result[k] = relative[k];
+            });
+            result.href = result.format();
+            return result;
+          }
+          result.protocol = relative.protocol;
+          if (!relative.host && !hostlessProtocol[relative.protocol]) {
+            var relPath = (relative.pathname || "").split("/");
+            while (relPath.length && !(relative.host = relPath.shift())) ;
+            if (!relative.host) relative.host = "";
+            if (!relative.hostname) relative.hostname = "";
+            if (relPath[0] !== "") relPath.unshift("");
+            if (relPath.length < 2) relPath.unshift("");
+            result.pathname = relPath.join("/");
+          } else {
+            result.pathname = relative.pathname;
+          }
+          result.search = relative.search;
+          result.query = relative.query;
+          result.host = relative.host || "";
+          result.auth = relative.auth;
+          result.hostname = relative.hostname || relative.host;
+          result.port = relative.port;
+          if (result.pathname || result.search) {
+            var p = result.pathname || "";
+            var s = result.search || "";
+            result.path = p + s;
+          }
+          result.slashes = result.slashes || relative.slashes;
+          result.href = result.format();
+          return result;
+        }
+        var isSourceAbs = result.pathname && result.pathname.charAt(0) === "/", isRelAbs = relative.host || relative.pathname && relative.pathname.charAt(0) === "/", mustEndAbs = isRelAbs || isSourceAbs || result.host && relative.pathname, removeAllDots = mustEndAbs, srcPath = result.pathname && result.pathname.split("/") || [], relPath = relative.pathname && relative.pathname.split("/") || [], psychotic = result.protocol && !slashedProtocol[result.protocol];
+        if (psychotic) {
+          result.hostname = "";
+          result.port = null;
+          if (result.host) {
+            if (srcPath[0] === "") srcPath[0] = result.host;
+            else srcPath.unshift(result.host);
+          }
+          result.host = "";
+          if (relative.protocol) {
+            relative.hostname = null;
+            relative.port = null;
+            if (relative.host) {
+              if (relPath[0] === "") relPath[0] = relative.host;
+              else relPath.unshift(relative.host);
+            }
+            relative.host = null;
+          }
+          mustEndAbs = mustEndAbs && (relPath[0] === "" || srcPath[0] === "");
+        }
+        if (isRelAbs) {
+          result.host = relative.host || relative.host === "" ? relative.host : result.host;
+          result.hostname = relative.hostname || relative.hostname === "" ? relative.hostname : result.hostname;
+          result.search = relative.search;
+          result.query = relative.query;
+          srcPath = relPath;
+        } else if (relPath.length) {
+          if (!srcPath) srcPath = [];
+          srcPath.pop();
+          srcPath = srcPath.concat(relPath);
+          result.search = relative.search;
+          result.query = relative.query;
+        } else if (!isNullOrUndefined(relative.search)) {
+          if (psychotic) {
+            result.hostname = result.host = srcPath.shift();
+            var authInHost = result.host && result.host.indexOf("@") > 0 ? result.host.split("@") : false;
+            if (authInHost) {
+              result.auth = authInHost.shift();
+              result.host = result.hostname = authInHost.shift();
+            }
+          }
+          result.search = relative.search;
+          result.query = relative.query;
+          if (!isNull(result.pathname) || !isNull(result.search)) {
+            result.path = (result.pathname ? result.pathname : "") + (result.search ? result.search : "");
+          }
+          result.href = result.format();
+          return result;
+        }
+        if (!srcPath.length) {
+          result.pathname = null;
+          if (result.search) {
+            result.path = "/" + result.search;
+          } else {
+            result.path = null;
+          }
+          result.href = result.format();
+          return result;
+        }
+        var last = srcPath.slice(-1)[0];
+        var hasTrailingSlash = (result.host || relative.host) && (last === "." || last === "..") || last === "";
+        var up = 0;
+        for (var i = srcPath.length; i >= 0; i--) {
+          last = srcPath[i];
+          if (last == ".") {
+            srcPath.splice(i, 1);
+          } else if (last === "..") {
+            srcPath.splice(i, 1);
+            up++;
+          } else if (up) {
+            srcPath.splice(i, 1);
+            up--;
+          }
+        }
+        if (!mustEndAbs && !removeAllDots) {
+          for (; up--; up) {
+            srcPath.unshift("..");
+          }
+        }
+        if (mustEndAbs && srcPath[0] !== "" && (!srcPath[0] || srcPath[0].charAt(0) !== "/")) {
+          srcPath.unshift("");
+        }
+        if (hasTrailingSlash && srcPath.join("/").substr(-1) !== "/") {
+          srcPath.push("");
+        }
+        var isAbsolute = srcPath[0] === "" || srcPath[0] && srcPath[0].charAt(0) === "/";
+        if (psychotic) {
+          result.hostname = result.host = isAbsolute ? "" : srcPath.length ? srcPath.shift() : "";
+          var authInHost = result.host && result.host.indexOf("@") > 0 ? result.host.split("@") : false;
+          if (authInHost) {
+            result.auth = authInHost.shift();
+            result.host = result.hostname = authInHost.shift();
+          }
+        }
+        mustEndAbs = mustEndAbs || result.host && srcPath.length;
+        if (mustEndAbs && !isAbsolute) {
+          srcPath.unshift("");
+        }
+        if (!srcPath.length) {
+          result.pathname = null;
+          result.path = null;
+        } else {
+          result.pathname = srcPath.join("/");
+        }
+        if (!isNull(result.pathname) || !isNull(result.search)) {
+          result.path = (result.pathname ? result.pathname : "") + (result.search ? result.search : "");
+        }
+        result.auth = relative.auth || result.auth;
+        result.slashes = result.slashes || relative.slashes;
+        result.href = result.format();
+        return result;
+      };
+      Url.prototype.parseHost = function() {
+        var host = this.host;
+        var port = portPattern.exec(host);
+        if (port) {
+          port = port[0];
+          if (port !== ":") {
+            this.port = port.substr(1);
+          }
+          host = host.substr(0, host.length - port.length);
+        }
+        if (host) this.hostname = host;
+      };
+      function isString(arg) {
+        return typeof arg === "string";
+      }
+      function isObject(arg) {
+        return typeof arg === "object" && arg !== null;
+      }
+      function isNull(arg) {
+        return arg === null;
+      }
+      function isNullOrUndefined(arg) {
+        return arg == null;
+      }
+    }
+  });
+
+  // lib/fuzzy_url_equals.js
+  function fuzzyUrlEquals(one, other) {
+    other = encodeURI(other);
+    return fuzzyIncludes(one, other) || fuzzyIncludes(other, one);
+  }
+  function fuzzyIncludes(one, other) {
+    return one.indexOf(other) !== -1 || other.charAt(other.length - 1) === "/" && one.indexOf(other.slice(0, -1)) !== -1;
+  }
+  var init_fuzzy_url_equals = __esm({
+    "lib/fuzzy_url_equals.js"() {
+      "use strict";
+    }
+  });
+
+  // lib/model.js
+  var Account, Credentials, DAVCollection, AddressBook, Calendar, DAVObject, CalendarObject, VCard;
+  var init_model = __esm({
+    "lib/model.js"() {
+      Account = class {
+        constructor(options) {
+          Object.assign(this, {
+            server: null,
+            credentials: null,
+            rootUrl: null,
+            principalUrl: null,
+            homeUrl: null,
+            calendars: null,
+            addressBooks: null
+          }, options);
+        }
+      };
+      Credentials = class {
+        constructor(options) {
+          Object.assign(this, {
+            username: null,
+            password: null,
+            clientId: null,
+            clientSecret: null,
+            authorizationCode: null,
+            redirectUrl: null,
+            tokenUrl: null,
+            accessToken: null,
+            refreshToken: null,
+            expiration: null
+          }, options);
+        }
+      };
+      DAVCollection = class {
+        constructor(options) {
+          Object.assign(this, {
+            data: null,
+            objects: null,
+            account: null,
+            ctag: null,
+            description: null,
+            displayName: null,
+            reports: null,
+            resourcetype: null,
+            syncToken: null,
+            url: null
+          }, options);
+        }
+      };
+      AddressBook = class extends DAVCollection {
+        constructor(options) {
+          super(options);
+        }
+      };
+      Calendar = class extends DAVCollection {
+        constructor(options) {
+          super(options);
+          Object.assign(this, {
+            components: null,
+            timezone: null
+          }, options);
+        }
+      };
+      DAVObject = class {
+        constructor(options) {
+          Object.assign(this, {
+            data: null,
+            etag: null,
+            url: null
+          }, options);
+        }
+      };
+      CalendarObject = class extends DAVObject {
+        constructor(options) {
+          super(options);
+          Object.assign(this, {
+            calendar: null,
+            calendarData: null
+          }, options);
+        }
+      };
+      VCard = class extends DAVObject {
+        constructor(options) {
+          super(options);
+          Object.assign(this, {
+            addressBook: null,
+            addressData: null
+          }, options);
+        }
+      };
+    }
+  });
+
+  // lib/webdav.js
+  function createObject(objectUrl, objectData2, options) {
+    var req = basic({ method: "PUT", data: objectData2, contentType: "text/vcard;charset=utf-8" });
+    return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
+  }
+  function updateObject(objectUrl, objectData2, etag, options) {
+    var req = basic({ method: "PUT", data: objectData2, etag, contentType: "text/vcard;charset=utf-8" });
+    return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
+  }
+  function deleteObject(objectUrl, etag, options) {
+    var req = basic({ method: "DELETE", etag });
+    return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
+  }
+  function syncCollection4(collection, options) {
+    let syncMethod;
+    if ("syncMethod" in options) {
+      syncMethod = options.syncMethod;
+    } else if (collection.reports && collection.reports.indexOf("syncCollection") !== -1) {
+      syncMethod = "webdav";
+    } else {
+      syncMethod = "basic";
+    }
+    if (syncMethod === "webdav") {
+      debug3("rfc 6578 sync.");
+      return options.webdavSync(collection, options);
+    } else {
+      debug3("basic sync.");
+      return options.basicSync(collection, options);
+    }
+  }
+  function updateProperties(objectUrl, options) {
+    var req = proppatch3({
+      props: options.props
+    });
+    return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
+  }
+  function createCollection(collectionUrl, options) {
+    var req = mkcol3({
+      props: options.props
+    });
+    return options.xhr.send(req, collectionUrl, { sandbox: options.sandbox });
+  }
+  function deleteCollection(collectionUrl, options) {
+    var req = basic({ method: "DELETE" });
+    return options.xhr.send(req, collectionUrl, { sandbox: options.sandbox });
+  }
+  var import_co2, debug3, supportedReportSet, isCollectionDirty;
+  var init_webdav = __esm({
+    "lib/webdav.js"() {
+      import_co2 = __toESM(require_co());
+      init_fuzzy_url_equals();
+      init_namespace();
+      init_request();
+      debug3 = require_debug()("dav:webdav");
+      supportedReportSet = import_co2.default.wrap(function* (collection, options) {
+        debug3("Checking supported report set for collection at " + collection.url);
+        var req = propfind3({
+          props: [{ name: "supported-report-set", namespace: DAV }],
+          depth: 1,
           mergeResponses: true
         });
-        context$1$0.next = 4;
-        return options.xhr.send(req, account.rootUrl, {
+        let response = yield options.xhr.send(req, collection.url, {
           sandbox: options.sandbox
         });
-
-      case 4:
-        res = context$1$0.sent;
-        container = res.props;
-
-        debug('Received principal: ' + container.currentUserPrincipal);
-        return context$1$0.abrupt('return', _url2['default'].resolve(account.rootUrl, container.currentUserPrincipal));
-
-      case 8:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-/**
- * @param {dav.Account} account to get home url for.
- */
-var homeUrl = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account, options) {
-  var prop, req, responses, response, container, href;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Fetch home url from principal url ' + account.principalUrl + '.');
-        prop = undefined;
-
-        if (options.accountType === 'caldav') {
-          prop = { name: 'calendar-home-set', namespace: ns.CALDAV };
-        } else if (options.accountType === 'carddav') {
-          prop = { name: 'addressbook-home-set', namespace: ns.CARDDAV };
+        return response.props.supportedReportSet;
+      });
+      isCollectionDirty = import_co2.default.wrap(function* (collection, options) {
+        if (!collection.ctag) {
+          debug3("Missing ctag.");
+          return false;
         }
-
-        req = request.propfind({ props: [prop] });
-        context$1$0.next = 6;
-        return options.xhr.send(req, account.principalUrl, {
+        debug3("Fetch remote getctag prop.");
+        var req = propfind3({
+          props: [{ name: "getctag", namespace: CALENDAR_SERVER }],
+          depth: 0
+        });
+        let responses = yield options.xhr.send(req, collection.account.homeUrl, {
           sandbox: options.sandbox
         });
-
-      case 6:
-        responses = context$1$0.sent;
-        response = responses.find(function (response) {
-          return (0, _fuzzy_url_equals2['default'])(account.principalUrl, response.href);
-        });
-        container = response.props;
-        href = undefined;
-
-        if (options.accountType === 'caldav') {
-          debug('Received home: ' + container.calendarHomeSet);
-          href = container.calendarHomeSet;
-        } else if (options.accountType === 'carddav') {
-          debug('Received home: ' + container.addressbookHomeSet);
-          href = container.addressbookHomeSet;
+        let response = responses.filter((response2) => {
+          return fuzzyUrlEquals(collection.url, response2.href);
+        })[0];
+        if (!response) {
+          throw new Error("Could not find collection on remote. Was it deleted?");
         }
-
-        return context$1$0.abrupt('return', _url2['default'].resolve(account.rootUrl, href));
-
-      case 12:
-      case 'end':
-        return context$1$0.stop();
+        debug3("Check whether cached ctag matches remote.");
+        return collection.ctag !== response.props.getctag;
+      });
     }
-  }, callee$0$0, this);
-}));
+  });
 
-/**
- * Options:
- *
- *   (String) accountType - one of 'caldav' or 'carddav'. Defaults to 'caldav'.
- *   (Array.<Object>) filters - list of caldav filters to send with request.
- *   (Boolean) loadCollections - whether or not to load dav collections.
- *   (Boolean) loadObjects - whether or not to load dav objects.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (String) server - some url for server (needn't be base url).
- *   (String) timezone - VTIMEZONE calendar object.
- *   (dav.Transport) xhr - request sender.
- *
- * @return {Promise} a promise that will resolve with a dav.Account object.
- */
-exports.createAccount = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(options) {
-  var account, key, loadCollections, loadObjects, collections;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        options = Object.assign({}, defaults, options);
-        if (typeof options.loadObjects !== 'boolean') {
-          options.loadObjects = options.loadCollections;
-        }
-
-        account = new _model.Account({
-          server: options.server,
-          credentials: options.xhr.credentials
-        });
-        context$1$0.next = 5;
-        return serviceDiscovery(account, options);
-
-      case 5:
-        account.rootUrl = context$1$0.sent;
-        context$1$0.next = 8;
-        return principalUrl(account, options);
-
-      case 8:
-        account.principalUrl = context$1$0.sent;
-        context$1$0.next = 11;
-        return homeUrl(account, options);
-
-      case 11:
-        account.homeUrl = context$1$0.sent;
-
-        if (options.loadCollections) {
-          context$1$0.next = 14;
-          break;
-        }
-
-        return context$1$0.abrupt('return', account);
-
-      case 14:
-        key = undefined, loadCollections = undefined, loadObjects = undefined;
-
-        if (options.accountType === 'caldav') {
-          key = 'calendars';
-          loadCollections = _calendars.listCalendars;
-          loadObjects = _calendars.listCalendarObjects;
-        } else if (options.accountType === 'carddav') {
-          key = 'addressBooks';
-          loadCollections = _contacts.listAddressBooks;
-          loadObjects = _contacts.listVCards;
-        }
-
-        context$1$0.next = 18;
-        return loadCollections(account, options);
-
-      case 18:
-        collections = context$1$0.sent;
-
-        account[key] = collections;
-
-        if (options.loadObjects) {
-          context$1$0.next = 22;
-          break;
-        }
-
-        return context$1$0.abrupt('return', account);
-
-      case 22:
-        context$1$0.next = 24;
-        return collections.map(_co2['default'].wrap(regeneratorRuntime.mark(function callee$1$0(collection) {
-          return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-            while (1) switch (context$2$0.prev = context$2$0.next) {
-              case 0:
-                context$2$0.prev = 0;
-                context$2$0.next = 3;
-                return loadObjects(collection, options);
-
-              case 3:
-                collection.objects = context$2$0.sent;
-                context$2$0.next = 9;
-                break;
-
-              case 6:
-                context$2$0.prev = 6;
-                context$2$0.t0 = context$2$0['catch'](0);
-
-                collection.error = context$2$0.t0;
-
-              case 9:
-              case 'end':
-                return context$2$0.stop();
-            }
-          }, callee$1$0, this, [[0, 6]]);
-        })));
-
-      case 24:
-
-        account[key] = account[key].filter(function (collection) {
-          return !collection.error;
-        });
-
-        return context$1$0.abrupt('return', account);
-
-      case 26:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-// http redirect.
-},{"./calendars":2,"./contacts":5,"./debug":6,"./fuzzy_url_equals":7,"./model":9,"./namespace":10,"./request":12,"co":26,"url":31}],2:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.createCalendarObject = createCalendarObject;
-exports.updateCalendarObject = updateCalendarObject;
-exports.deleteCalendarObject = deleteCalendarObject;
-exports.syncCalendar = syncCalendar;
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _co = require('co');
-
-var _co2 = _interopRequireDefault(_co);
-
-var _url = require('url');
-
-var _url2 = _interopRequireDefault(_url);
-
-var _fuzzy_url_equals = require('./fuzzy_url_equals');
-
-var _fuzzy_url_equals2 = _interopRequireDefault(_fuzzy_url_equals);
-
-var _model = require('./model');
-
-var _namespace = require('./namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-var _request = require('./request');
-
-var request = _interopRequireWildcard(_request);
-
-var _webdav = require('./webdav');
-
-var webdav = _interopRequireWildcard(_webdav);
-
-var debug = require('./debug')('dav:calendars');
-
-var ICAL_OBJS = new Set(['VEVENT', 'VTODO', 'VJOURNAL', 'VFREEBUSY', 'VTIMEZONE', 'VALARM']);
-
-/**
- * @param {dav.Account} account to fetch calendars for.
- */
-var listCalendars = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account, options) {
-  var req, responses, cals;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Fetch calendars from home url ' + account.homeUrl);
-        req = request.propfind({
-          props: [{ name: 'calendar-description', namespace: ns.CALDAV }, { name: 'calendar-timezone', namespace: ns.CALDAV }, { name: 'displayname', namespace: ns.DAV }, { name: 'getctag', namespace: ns.CALENDAR_SERVER }, { name: 'resourcetype', namespace: ns.DAV }, { name: 'supported-calendar-component-set', namespace: ns.CALDAV }, { name: 'sync-token', namespace: ns.DAV }],
+  // lib/calendars.js
+  var calendars_exports = {};
+  __export(calendars_exports, {
+    createCalendarObject: () => createCalendarObject,
+    deleteCalendarObject: () => deleteCalendarObject,
+    listCalendarObjects: () => listCalendarObjects,
+    listCalendars: () => listCalendars,
+    syncCaldavAccount: () => syncCaldavAccount,
+    syncCalendar: () => syncCalendar,
+    updateCalendarObject: () => updateCalendarObject
+  });
+  function createCalendarObject(calendar, options) {
+    var objectUrl = import_url.default.resolve(calendar.url, options.filename);
+    return createObject(objectUrl, options.data, options);
+  }
+  function updateCalendarObject(calendarObject, options) {
+    return updateObject(
+      calendarObject.url,
+      calendarObject.calendarData,
+      calendarObject.etag,
+      options
+    );
+  }
+  function deleteCalendarObject(calendarObject, options) {
+    return deleteObject(
+      calendarObject.url,
+      calendarObject.etag,
+      options
+    );
+  }
+  function syncCalendar(calendar, options) {
+    options.basicSync = basicSync;
+    options.webdavSync = webdavSync;
+    return syncCollection4(calendar, options);
+  }
+  var import_co3, import_url, debug4, ICAL_OBJS, listCalendars, listCalendarObjects, syncCaldavAccount, basicSync, webdavSync;
+  var init_calendars = __esm({
+    "lib/calendars.js"() {
+      import_co3 = __toESM(require_co());
+      import_url = __toESM(require_url());
+      init_fuzzy_url_equals();
+      init_model();
+      init_namespace();
+      init_request();
+      init_webdav();
+      debug4 = require_debug()("dav:calendars");
+      ICAL_OBJS = /* @__PURE__ */ new Set([
+        "VEVENT",
+        "VTODO",
+        "VJOURNAL",
+        "VFREEBUSY",
+        "VTIMEZONE",
+        "VALARM"
+      ]);
+      listCalendars = import_co3.default.wrap(function* (account, options) {
+        debug4(`Fetch calendars from home url ${account.homeUrl}`);
+        var req = propfind3({
+          props: [
+            { name: "calendar-description", namespace: CALDAV },
+            { name: "calendar-timezone", namespace: CALDAV },
+            { name: "displayname", namespace: DAV },
+            { name: "getctag", namespace: CALENDAR_SERVER },
+            { name: "resourcetype", namespace: DAV },
+            { name: "supported-calendar-component-set", namespace: CALDAV },
+            { name: "sync-token", namespace: DAV }
+          ],
           depth: 1
         });
-        context$1$0.next = 4;
-        return options.xhr.send(req, account.homeUrl, {
+        let responses = yield options.xhr.send(req, account.homeUrl, {
           sandbox: options.sandbox
         });
-
-      case 4:
-        responses = context$1$0.sent;
-
-        debug('Found ' + responses.length + ' calendars.');
-        cals = responses.filter(function (res) {
-          // We only want the calendar if it contains iCalendar objects.
-          var components = res.props.supportedCalendarComponentSet || [];
-          return components.reduce(function (hasObjs, component) {
+        debug4(`Found ${responses.length} calendars.`);
+        let cals = responses.filter((res) => {
+          let components = res.props.supportedCalendarComponentSet || [];
+          return components.reduce((hasObjs, component) => {
             return hasObjs || ICAL_OBJS.has(component);
           }, false);
-        }).map(function (res) {
-          debug('Found calendar ' + res.props.displayname + ',\n             props: ' + JSON.stringify(res.props));
-          return new _model.Calendar({
+        }).map((res) => {
+          debug4(`Found calendar ${res.props.displayname},
+             props: ${JSON.stringify(res.props)}`);
+          return new Calendar({
             data: res,
-            account: account,
+            account,
             description: res.props.calendarDescription,
             timezone: res.props.calendarTimezone,
-            url: _url2['default'].resolve(account.rootUrl, res.href),
+            url: import_url.default.resolve(account.rootUrl, res.href),
             ctag: res.props.getctag,
             displayName: res.props.displayname,
             components: res.props.supportedCalendarComponentSet,
@@ -1026,6497 +6449,867 @@ var listCalendars = _co2['default'].wrap(regeneratorRuntime.mark(function callee
             syncToken: res.props.syncToken
           });
         });
-        context$1$0.next = 9;
-        return cals.map(_co2['default'].wrap(regeneratorRuntime.mark(function callee$1$0(cal) {
-          return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-            while (1) switch (context$2$0.prev = context$2$0.next) {
-              case 0:
-                context$2$0.next = 2;
-                return webdav.supportedReportSet(cal, options);
-
-              case 2:
-                cal.reports = context$2$0.sent;
-
-              case 3:
-              case 'end':
-                return context$2$0.stop();
-            }
-          }, callee$1$0, this);
-        })));
-
-      case 9:
-        return context$1$0.abrupt('return', cals);
-
-      case 10:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.listCalendars = listCalendars;
-/**
- * @param {dav.Calendar} calendar the calendar to put the object on.
- * @return {Promise} promise will resolve when the calendar has been created.
- *
- * Options:
- *
- *   (String) data - rfc 5545 VCALENDAR object.
- *   (String) filename - name for the calendar ics file.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function createCalendarObject(calendar, options) {
-  var objectUrl = _url2['default'].resolve(calendar.url, options.filename);
-  return webdav.createObject(objectUrl, options.data, options);
-}
-
-;
-
-/**
- * @param {dav.CalendarObject} calendarObject updated calendar object.
- * @return {Promise} promise will resolve when the calendar has been updated.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function updateCalendarObject(calendarObject, options) {
-  return webdav.updateObject(calendarObject.url, calendarObject.calendarData, calendarObject.etag, options);
-}
-
-/**
- * @param {dav.CalendarObject} calendarObject target calendar object.
- * @return {Promise} promise will resolve when the calendar has been deleted.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function deleteCalendarObject(calendarObject, options) {
-  return webdav.deleteObject(calendarObject.url, calendarObject.etag, options);
-}
-
-/**
- * @param {dav.Calendar} calendar the calendar to fetch objects for.
- *
- * Options:
- *
- *   (Array.<Object>) filters - optional caldav filters.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-var listCalendarObjects = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(calendar, options) {
-  var filters, req, responses;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Doing REPORT on calendar ' + calendar.url + ' which belongs to\n         ' + calendar.account.credentials.username);
-
-        filters = options.filters || [{
-          type: 'comp-filter',
-          attrs: { name: 'VCALENDAR' },
+        yield cals.map(import_co3.default.wrap(function* (cal) {
+          cal.reports = yield supportedReportSet(cal, options);
+        }));
+        return cals;
+      });
+      listCalendarObjects = import_co3.default.wrap(function* (calendar, options) {
+        debug4(`Doing REPORT on calendar ${calendar.url} which belongs to
+         ${calendar.account.credentials.username}`);
+        let filters = options.filters || [{
+          type: "comp-filter",
+          attrs: { name: "VCALENDAR" },
           children: [{
-            type: 'comp-filter',
-            attrs: { name: 'VEVENT' }
+            type: "comp-filter",
+            attrs: { name: "VEVENT" }
           }]
         }];
-        req = request.calendarQuery({
+        let req = calendarQuery3({
           depth: 1,
-          props: [{ name: 'getetag', namespace: ns.DAV }, { name: 'calendar-data', namespace: ns.CALDAV }],
-          filters: filters
+          props: [
+            { name: "getetag", namespace: DAV },
+            { name: "calendar-data", namespace: CALDAV }
+          ],
+          filters
         });
-        context$1$0.next = 5;
-        return options.xhr.send(req, calendar.url, {
+        let responses = yield options.xhr.send(req, calendar.url, {
           sandbox: options.sandbox
         });
-
-      case 5:
-        responses = context$1$0.sent;
-        return context$1$0.abrupt('return', responses.map(function (res) {
-          debug('Found calendar object with url ' + res.href);
-          return new _model.CalendarObject({
+        return responses.map((res) => {
+          debug4(`Found calendar object with url ${res.href}`);
+          return new CalendarObject({
             data: res,
-            calendar: calendar,
-            url: _url2['default'].resolve(calendar.account.rootUrl, res.href),
+            calendar,
+            url: import_url.default.resolve(calendar.account.rootUrl, res.href),
             etag: res.props.getetag,
             calendarData: res.props.calendarData
           });
-        }));
-
-      case 7:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.listCalendarObjects = listCalendarObjects;
-/**
- * @param {dav.Calendar} calendar the calendar to fetch updates to.
- * @return {Promise} promise will resolve with updated calendar object.
- *
- * Options:
- *
- *   (Array.<Object>) filters - list of caldav filters to send with request.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (String) syncMethod - either 'basic' or 'webdav'. If unspecified, will
- *       try to do webdav sync and failover to basic sync if rfc 6578 is not
- *       supported by the server.
- *   (String) timezone - VTIMEZONE calendar object.
- *   (dav.Transport) xhr - request sender.
- */
-
-function syncCalendar(calendar, options) {
-  options.basicSync = basicSync;
-  options.webdavSync = webdavSync;
-  return webdav.syncCollection(calendar, options);
-}
-
-/**
- * @param {dav.Account} account the account to fetch updates for.
- * @return {Promise} promise will resolve with updated account.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-var syncCaldavAccount = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-  var cals;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
+        });
+      });
+      syncCaldavAccount = import_co3.default.wrap(function* (account, options = {}) {
         options.loadObjects = false;
         if (!account.calendars) account.calendars = [];
-
-        context$1$0.next = 4;
-        return listCalendars(account, options);
-
-      case 4:
-        cals = context$1$0.sent;
-
-        cals.filter(function (cal) {
-          // Filter the calendars not previously seen.
-          return account.calendars.every(function (prev) {
-            return !(0, _fuzzy_url_equals2['default'])(prev.url, cal.url);
-          });
-        }).forEach(function (cal) {
-          // Add them to the account's calendar list.
+        let cals = yield listCalendars(account, options);
+        cals.filter((cal) => {
+          return account.calendars.every((prev) => !fuzzyUrlEquals(prev.url, cal.url));
+        }).forEach((cal) => {
           account.calendars.push(cal);
         });
-
         options.loadObjects = true;
-        context$1$0.next = 9;
-        return account.calendars.map(_co2['default'].wrap(regeneratorRuntime.mark(function callee$1$0(cal, index) {
-          return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-            while (1) switch (context$2$0.prev = context$2$0.next) {
-              case 0:
-                context$2$0.prev = 0;
-                context$2$0.next = 3;
-                return syncCalendar(cal, options);
-
-              case 3:
-                context$2$0.next = 9;
-                break;
-
-              case 5:
-                context$2$0.prev = 5;
-                context$2$0.t0 = context$2$0['catch'](0);
-
-                debug('Sync calendar ' + cal.displayName + ' failed with ' + context$2$0.t0);
-                account.calendars.splice(index, 1);
-
-              case 9:
-              case 'end':
-                return context$2$0.stop();
-            }
-          }, callee$1$0, this, [[0, 5]]);
-        })));
-
-      case 9:
-        return context$1$0.abrupt('return', account);
-
-      case 10:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.syncCaldavAccount = syncCaldavAccount;
-var basicSync = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(calendar, options) {
-  var sync;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        context$1$0.next = 2;
-        return webdav.isCollectionDirty(calendar, options);
-
-      case 2:
-        sync = context$1$0.sent;
-
-        if (sync) {
-          context$1$0.next = 6;
-          break;
+        yield account.calendars.map(import_co3.default.wrap(function* (cal, index) {
+          try {
+            yield syncCalendar(cal, options);
+          } catch (error) {
+            debug4(`Sync calendar ${cal.displayName} failed with ${error}`);
+            account.calendars.splice(index, 1);
+          }
+        }));
+        return account;
+      });
+      basicSync = import_co3.default.wrap(function* (calendar, options) {
+        let sync = yield isCollectionDirty(calendar, options);
+        if (!sync) {
+          debug4("Local ctag matched remote! No need to sync :).");
+          return calendar;
         }
-
-        debug('Local ctag matched remote! No need to sync :).');
-        return context$1$0.abrupt('return', calendar);
-
-      case 6:
-
-        debug('ctag changed so we need to fetch stuffs.');
-        context$1$0.next = 9;
-        return listCalendarObjects(calendar, options);
-
-      case 9:
-        calendar.objects = context$1$0.sent;
-        return context$1$0.abrupt('return', calendar);
-
-      case 11:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-var webdavSync = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(calendar, options) {
-  var req, result;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        req = request.syncCollection({
-          props: [{ name: 'getetag', namespace: ns.DAV }, { name: 'calendar-data', namespace: ns.CALDAV }],
+        debug4("ctag changed so we need to fetch stuffs.");
+        calendar.objects = yield listCalendarObjects(calendar, options);
+        return calendar;
+      });
+      webdavSync = import_co3.default.wrap(function* (calendar, options) {
+        var req = syncCollection3({
+          props: [
+            { name: "getetag", namespace: DAV },
+            { name: "calendar-data", namespace: CALDAV }
+          ],
           syncLevel: 1,
           syncToken: calendar.syncToken
         });
-        context$1$0.next = 3;
-        return options.xhr.send(req, calendar.url, {
+        let result = yield options.xhr.send(req, calendar.url, {
           sandbox: options.sandbox
         });
-
-      case 3:
-        result = context$1$0.sent;
-
-        // TODO(gareth): Handle creations and deletions.
-        result.responses.forEach(function (response) {
-          // Find the calendar object that this response corresponds with.
-          var calendarObject = calendar.objects.filter(function (object) {
-            return (0, _fuzzy_url_equals2['default'])(object.url, response.href);
+        result.responses.forEach(function(response) {
+          var calendarObject = calendar.objects.filter(function(object) {
+            return fuzzyUrlEquals(object.url, response.href);
           })[0];
-
           if (!calendarObject) {
             return;
           }
-
           calendarObject.etag = response.props.getetag;
           calendarObject.calendarData = response.props.calendarData;
         });
-
         calendar.syncToken = result.syncToken;
-        return context$1$0.abrupt('return', calendar);
-
-      case 7:
-      case 'end':
-        return context$1$0.stop();
+        return calendar;
+      });
     }
-  }, callee$0$0, this);
-}));
-},{"./debug":6,"./fuzzy_url_equals":7,"./model":9,"./namespace":10,"./request":12,"./webdav":24,"co":26,"url":31}],3:[function(require,module,exports){
-/**
- * @fileoverview Camelcase something.
- */
-'use strict';
+  });
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = camelize;
-
-function camelize(str) {
-  var delimiter = arguments.length <= 1 || arguments[1] === undefined ? '_' : arguments[1];
-
-  var words = str.split(delimiter);
-  return [words[0]].concat(words.slice(1).map(function (word) {
-    return word.charAt(0).toUpperCase() + word.slice(1);
-  })).join('');
-}
-
-module.exports = exports['default'];
-},{}],4:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-var _url = require('url');
-
-var _url2 = _interopRequireDefault(_url);
-
-var _accounts = require('./accounts');
-
-var accounts = _interopRequireWildcard(_accounts);
-
-var _calendars = require('./calendars');
-
-var calendars = _interopRequireWildcard(_calendars);
-
-var _contacts = require('./contacts');
-
-var contacts = _interopRequireWildcard(_contacts);
-
-/**
- * @param {dav.Transport} xhr - request sender.
- *
- * Options:
- *
- *   (String) baseUrl - root url to resolve relative request urls with.
- */
-
-var Client = (function () {
-  function Client(xhr) {
-    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-    _classCallCheck(this, Client);
-
-    this.xhr = xhr;
-    Object.assign(this, options);
-
-    // Expose internal modules for unit testing
-    this._accounts = accounts;
-    this._calendars = calendars;
-    this._contacts = contacts;
+  // lib/contacts.js
+  var contacts_exports = {};
+  __export(contacts_exports, {
+    createAddressBook: () => createAddressBook,
+    createCard: () => createCard,
+    deleteAddressBook: () => deleteAddressBook,
+    deleteCard: () => deleteCard,
+    getAddressBook: () => getAddressBook,
+    listAddressBooks: () => listAddressBooks,
+    listVCards: () => listVCards,
+    renameAddressBook: () => renameAddressBook,
+    syncAddressBook: () => syncAddressBook,
+    syncCarddavAccount: () => syncCarddavAccount,
+    updateCard: () => updateCard
+  });
+  function getAddressBook(options) {
+    let addressBookUrl = import_url2.default.resolve(options.url, options.displayName);
+    var req = propfind3({
+      props: [
+        { name: "displayname", namespace: DAV },
+        { name: "owner", namespace: DAV },
+        { name: "getctag", namespace: CALENDAR_SERVER },
+        { name: "resourcetype", namespace: DAV },
+        { name: "sync-token", namespace: DAV },
+        //{ name: 'groups', namespace: ns.OC },
+        { name: "invite", namespace: OC }
+      ],
+      depth: 1
+    });
+    return options.xhr.send(req, addressBookUrl);
   }
-
-  /**
-   * @param {dav.Request} req - dav request.
-   * @param {String} uri - where to send request.
-   * @return {Promise} a promise that will be resolved with an xhr request
-   *     after its readyState is 4 or the result of applying an optional
-   *     request `transformResponse` function to the xhr object after its
-   *     readyState is 4.
-   *
-   * Options:
-   *
-   *   (Object) sandbox - optional request sandbox.
-   */
-
-  _createClass(Client, [{
-    key: 'send',
-    value: function send(req, uri, options) {
-      if (this.baseUrl) {
-        var urlObj = _url2['default'].parse(uri);
-        uri = _url2['default'].resolve(this.baseUrl, urlObj.path);
-      }
-
-      return this.xhr.send(req, uri, options);
-    }
-  }, {
-    key: 'createAccount',
-    value: function createAccount() {
-      var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-      options.xhr = options.xhr || this.xhr;
-      return accounts.createAccount(options);
-    }
-  }, {
-    key: 'createCalendarObject',
-    value: function createCalendarObject(calendar) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return calendars.createCalendarObject(calendar, options);
-    }
-  }, {
-    key: 'updateCalendarObject',
-    value: function updateCalendarObject(calendarObject) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return calendars.updateCalendarObject(calendarObject, options);
-    }
-  }, {
-    key: 'deleteCalendarObject',
-    value: function deleteCalendarObject(calendarObject) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return calendars.deleteCalendarObject(calendarObject, options);
-    }
-  }, {
-    key: 'syncCalendar',
-    value: function syncCalendar(calendar) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return calendars.syncCalendar(calendar, options);
-    }
-  }, {
-    key: 'syncCaldavAccount',
-    value: function syncCaldavAccount(account) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return calendars.syncCaldavAccount(account, options);
-    }
-  }, {
-    key: 'getAddressBook',
-    value: function getAddressBook() {
-      var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.getAddressBook(options);
-    }
-  }, {
-    key: 'createAddressBook',
-    value: function createAddressBook() {
-      var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.createAddressBook(options);
-    }
-  }, {
-    key: 'deleteAddressBook',
-    value: function deleteAddressBook(addressBook) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.deleteAddressBook(addressBook, options);
-    }
-  }, {
-    key: 'renameAddressBook',
-    value: function renameAddressBook(addressBook) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.renameAddressBook(addressBook, options);
-    }
-  }, {
-    key: 'createCard',
-    value: function createCard(addressBook) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.createCard(addressBook, options);
-    }
-  }, {
-    key: 'updateCard',
-    value: function updateCard(card) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.updateCard(card, options);
-    }
-  }, {
-    key: 'deleteCard',
-    value: function deleteCard(card) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.deleteCard(card, options);
-    }
-  }, {
-    key: 'syncAddressBook',
-    value: function syncAddressBook(addressBook) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.syncAddressBook(addressBook, options);
-    }
-  }, {
-    key: 'syncCarddavAccount',
-    value: function syncCarddavAccount(account) {
-      var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-      options.xhr = options.xhr || this.xhr;
-      return contacts.syncCarddavAccount(account, options);
-    }
-  }]);
-
-  return Client;
-})();
-
-exports.Client = Client;
-},{"./accounts":1,"./calendars":2,"./contacts":5,"url":31}],5:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.getAddressBook = getAddressBook;
-exports.createAddressBook = createAddressBook;
-exports.deleteAddressBook = deleteAddressBook;
-exports.renameAddressBook = renameAddressBook;
-exports.createCard = createCard;
-exports.updateCard = updateCard;
-exports.deleteCard = deleteCard;
-exports.syncAddressBook = syncAddressBook;
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _co = require('co');
-
-var _co2 = _interopRequireDefault(_co);
-
-var _url = require('url');
-
-var _url2 = _interopRequireDefault(_url);
-
-var _fuzzy_url_equals = require('./fuzzy_url_equals');
-
-var _fuzzy_url_equals2 = _interopRequireDefault(_fuzzy_url_equals);
-
-var _model = require('./model');
-
-var _namespace = require('./namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-var _request = require('./request');
-
-var request = _interopRequireWildcard(_request);
-
-var _webdav = require('./webdav');
-
-var webdav = _interopRequireWildcard(_webdav);
-
-var debug = require('./debug')('dav:contacts');
-
-/**
- * @param {dav.Account} account to fetch address books for.
- */
-var listAddressBooks = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account, options) {
-  var req, responses, addressBooks;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Fetch address books from home url ' + account.homeUrl);
-        req = request.propfind({
-          props: [{ name: 'displayname', namespace: ns.DAV }, { name: 'owner', namespace: ns.DAV }, { name: 'getctag', namespace: ns.CALENDAR_SERVER }, { name: 'resourcetype', namespace: ns.DAV }, { name: 'sync-token', namespace: ns.DAV },
-          //{ name: 'groups', namespace: ns.OC },
-          { name: 'invite', namespace: ns.OC }],
+  function createAddressBook(options) {
+    let collectionUrl = import_url2.default.resolve(options.url, options.displayName);
+    options.props = [
+      {
+        name: "resourcetype",
+        namespace: DAV,
+        children: [
+          { name: "collection", namespace: DAV },
+          { name: "addressbook", namespace: CARDDAV }
+        ]
+      },
+      { name: "displayname", value: options.displayName, namespace: DAV }
+    ];
+    return createCollection(collectionUrl, options);
+  }
+  function deleteAddressBook(addressBook, options) {
+    return deleteCollection(addressBook.url, options);
+  }
+  function renameAddressBook(addressBook, options) {
+    options.props = [
+      { name: "displayname", value: options.displayName, namespace: DAV }
+    ];
+    return updateProperties(addressBook.url, options);
+  }
+  function createCard(addressBook, options) {
+    let objectUrl = import_url2.default.resolve(addressBook.url, options.filename);
+    return createObject(objectUrl, options.data, options);
+  }
+  function updateCard(card, options) {
+    return updateObject(
+      card.url,
+      card.addressData,
+      card.etag,
+      options
+    );
+  }
+  function deleteCard(card, options) {
+    return deleteObject(
+      card.url,
+      card.etag,
+      options
+    );
+  }
+  function syncAddressBook(addressBook, options) {
+    options.basicSync = basicSync2;
+    options.webdavSync = webdavSync2;
+    return syncCollection4(addressBook, options);
+  }
+  var import_co4, import_url2, debug5, listAddressBooks, listVCards, syncCarddavAccount, basicSync2, webdavSync2;
+  var init_contacts = __esm({
+    "lib/contacts.js"() {
+      import_co4 = __toESM(require_co());
+      import_url2 = __toESM(require_url());
+      init_fuzzy_url_equals();
+      init_model();
+      init_namespace();
+      init_request();
+      init_webdav();
+      debug5 = require_debug()("dav:contacts");
+      listAddressBooks = import_co4.default.wrap(function* (account, options) {
+        debug5(`Fetch address books from home url ${account.homeUrl}`);
+        var req = propfind3({
+          props: [
+            { name: "displayname", namespace: DAV },
+            { name: "owner", namespace: DAV },
+            { name: "getctag", namespace: CALENDAR_SERVER },
+            { name: "resourcetype", namespace: DAV },
+            { name: "sync-token", namespace: DAV },
+            //{ name: 'groups', namespace: ns.OC },
+            { name: "invite", namespace: OC }
+          ],
           depth: 1
         });
-        context$1$0.next = 4;
-        return options.xhr.send(req, account.homeUrl, {
+        let responses = yield options.xhr.send(req, account.homeUrl, {
           sandbox: options.sandbox
         });
-
-      case 4:
-        responses = context$1$0.sent;
-        addressBooks = responses.filter(function (res) {
-          return typeof res.props.displayname === 'string';
-        }).map(function (res) {
-          debug('Found address book named ' + res.props.displayname + ',\n             props: ' + JSON.stringify(res.props));
-          return new _model.AddressBook({
+        let addressBooks = responses.filter((res) => {
+          return typeof res.props.displayname === "string";
+        }).map((res) => {
+          debug5(`Found address book named ${res.props.displayname},
+             props: ${JSON.stringify(res.props)}`);
+          return new AddressBook({
             data: res,
-            account: account,
-            url: _url2['default'].resolve(account.rootUrl, res.href),
+            account,
+            url: import_url2.default.resolve(account.rootUrl, res.href),
             ctag: res.props.getctag,
             displayName: res.props.displayname,
             resourcetype: res.props.resourcetype,
             syncToken: res.props.syncToken
           });
         });
-        context$1$0.next = 8;
-        return addressBooks.map(_co2['default'].wrap(regeneratorRuntime.mark(function callee$1$0(addressBook) {
-          return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-            while (1) switch (context$2$0.prev = context$2$0.next) {
-              case 0:
-                context$2$0.next = 2;
-                return webdav.supportedReportSet(addressBook, options);
-
-              case 2:
-                addressBook.reports = context$2$0.sent;
-
-              case 3:
-              case 'end':
-                return context$2$0.stop();
-            }
-          }, callee$1$0, this);
-        })));
-
-      case 8:
-        return context$1$0.abrupt('return', addressBooks);
-
-      case 9:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.listAddressBooks = listAddressBooks;
-
-function getAddressBook(options) {
-  var addressBookUrl = _url2['default'].resolve(options.url, options.displayName);
-  var req = request.propfind({
-    props: [{ name: 'displayname', namespace: ns.DAV }, { name: 'owner', namespace: ns.DAV }, { name: 'getctag', namespace: ns.CALENDAR_SERVER }, { name: 'resourcetype', namespace: ns.DAV }, { name: 'sync-token', namespace: ns.DAV },
-    //{ name: 'groups', namespace: ns.OC },
-    { name: 'invite', namespace: ns.OC }],
-    depth: 1
-  });
-
-  return options.xhr.send(req, addressBookUrl);
-}
-
-/**
- * @return {Promise} promise will resolve when the addressBook has been created.
- *
- * Options:
- *
- *   (String) url
- *   (String) displayName - name for the address book.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function createAddressBook(options) {
-  var collectionUrl = _url2['default'].resolve(options.url, options.displayName);
-  options.props = [{ name: 'resourcetype', namespace: ns.DAV, children: [{ name: 'collection', namespace: ns.DAV }, { name: 'addressbook', namespace: ns.CARDDAV }]
-  }, { name: 'displayname', value: options.displayName, namespace: ns.DAV }];
-  return webdav.createCollection(collectionUrl, options);
-}
-
-/**
- * @param {dav.AddressBook} addressBook the address book to be deleted.
- * @return {Promise} promise will resolve when the addressBook has been deleted.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function deleteAddressBook(addressBook, options) {
-  return webdav.deleteCollection(addressBook.url, options);
-}
-
-/**
- * @param {dav.AddressBook} addressBook the address book to be renamed.
- * @return {Promise} promise will resolve when the addressBook has been renamed.
- *
- * Options:
- *
- *   (String) displayName - new name for the address book.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function renameAddressBook(addressBook, options) {
-  options.props = [{ name: 'displayname', value: options.displayName, namespace: ns.DAV }];
-  return webdav.updateProperties(addressBook.url, options);
-}
-
-/**
- * @param {dav.AddressBook} addressBook the address book to put the object on.
- * @return {Promise} promise will resolve when the card has been created.
- *
- * Options:
- *
- *   (String) data - vcard object.
- *   (String) filename - name for the address book vcf file.
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function createCard(addressBook, options) {
-  var objectUrl = _url2['default'].resolve(addressBook.url, options.filename);
-  return webdav.createObject(objectUrl, options.data, options);
-}
-
-/**
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- */
-var listVCards = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(addressBook, options) {
-  var req, responses;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Doing REPORT on address book ' + addressBook.url + ' which belongs to\n        ' + addressBook.account.credentials.username);
-
-        req = request.addressBookQuery({
+        yield addressBooks.map(import_co4.default.wrap(function* (addressBook) {
+          addressBook.reports = yield supportedReportSet(addressBook, options);
+        }));
+        return addressBooks;
+      });
+      listVCards = import_co4.default.wrap(function* (addressBook, options) {
+        debug5(`Doing REPORT on address book ${addressBook.url} which belongs to
+        ${addressBook.account.credentials.username}`);
+        var req = addressBookQuery3({
           depth: 1,
-          props: [{ name: 'getetag', namespace: ns.DAV }, { name: 'address-data', namespace: ns.CARDDAV }]
+          props: [
+            { name: "getetag", namespace: DAV },
+            { name: "address-data", namespace: CARDDAV }
+          ]
         });
-        context$1$0.next = 4;
-        return options.xhr.send(req, addressBook.url, {
+        let responses = yield options.xhr.send(req, addressBook.url, {
           sandbox: options.sandbox
         });
-
-      case 4:
-        responses = context$1$0.sent;
-        return context$1$0.abrupt('return', responses.map(function (res) {
-          debug('Found vcard with url ' + res.href);
-          return new _model.VCard({
+        return responses.map((res) => {
+          debug5(`Found vcard with url ${res.href}`);
+          return new VCard({
             data: res,
-            addressBook: addressBook,
-            url: _url2['default'].resolve(addressBook.account.rootUrl, res.href),
+            addressBook,
+            url: import_url2.default.resolve(addressBook.account.rootUrl, res.href),
             etag: res.props.getetag,
             addressData: res.props.addressData
           });
-        }));
-
-      case 6:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.listVCards = listVCards;
-/**
- * @param {dav.VCard} card updated vcard object.
- * @return {Promise} promise will resolve when the card has been updated.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function updateCard(card, options) {
-  return webdav.updateObject(card.url, card.addressData, card.etag, options);
-}
-
-/**
- * @param {dav.VCard} card target vcard object.
- * @return {Promise} promise will resolve when the calendar has been deleted.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-
-function deleteCard(card, options) {
-  return webdav.deleteObject(card.url, card.etag, options);
-}
-
-/**
- * @param {dav.Calendar} calendar the calendar to fetch updates to.
- * @return {Promise} promise will resolve with updated calendar object.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (String) syncMethod - either 'basic' or 'webdav'. If unspecified, will
- *       try to do webdav sync and failover to basic sync if rfc 6578 is not
- *       supported by the server.
- *   (dav.Transport) xhr - request sender.
- */
-
-function syncAddressBook(addressBook, options) {
-  options.basicSync = basicSync;
-  options.webdavSync = webdavSync;
-  return webdav.syncCollection(addressBook, options);
-}
-
-/**
- * @param {dav.Account} account the account to fetch updates for.
- * @return {Promise} promise will resolve with updated account.
- *
- * Options:
- *
- *   (dav.Sandbox) sandbox - optional request sandbox.
- *   (dav.Transport) xhr - request sender.
- */
-var syncCarddavAccount = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(account) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-  var addressBooks;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
+        });
+      });
+      syncCarddavAccount = import_co4.default.wrap(function* (account, options = {}) {
         options.loadObjects = false;
-
         if (!account.addressBooks) {
           account.addressBooks = [];
         }
-
-        context$1$0.next = 4;
-        return listAddressBooks(account, options);
-
-      case 4:
-        addressBooks = context$1$0.sent;
-
-        addressBooks.filter(function (addressBook) {
-          // Filter the address books not previously seen.
-          return account.addressBooks.every(function (prev) {
-            return !(0, _fuzzy_url_equals2['default'])(prev.url, addressBook.url);
-          });
-        }).forEach(function (addressBook) {
-          return account.addressBooks.push(addressBook);
-        });
-
+        let addressBooks = yield listAddressBooks(account, options);
+        addressBooks.filter(function(addressBook) {
+          return account.addressBooks.every(
+            (prev) => !fuzzyUrlEquals(prev.url, addressBook.url)
+          );
+        }).forEach((addressBook) => account.addressBooks.push(addressBook));
         options.loadObjects = true;
-        context$1$0.next = 9;
-        return account.addressBooks.map(_co2['default'].wrap(regeneratorRuntime.mark(function callee$1$0(addressBook, index) {
-          return regeneratorRuntime.wrap(function callee$1$0$(context$2$0) {
-            while (1) switch (context$2$0.prev = context$2$0.next) {
-              case 0:
-                context$2$0.prev = 0;
-                context$2$0.next = 3;
-                return syncAddressBook(addressBook, options);
-
-              case 3:
-                context$2$0.next = 9;
-                break;
-
-              case 5:
-                context$2$0.prev = 5;
-                context$2$0.t0 = context$2$0['catch'](0);
-
-                debug('Syncing ' + addressBook.displayName + ' failed with ' + context$2$0.t0);
-                account.addressBooks.splice(index, 1);
-
-              case 9:
-              case 'end':
-                return context$2$0.stop();
-            }
-          }, callee$1$0, this, [[0, 5]]);
-        })));
-
-      case 9:
-        return context$1$0.abrupt('return', account);
-
-      case 10:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.syncCarddavAccount = syncCarddavAccount;
-var basicSync = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(addressBook, options) {
-  var sync;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        sync = webdav.isCollectionDirty(addressBook, options);
-
-        if (sync) {
-          context$1$0.next = 4;
-          break;
+        yield account.addressBooks.map(import_co4.default.wrap(function* (addressBook, index) {
+          try {
+            yield syncAddressBook(addressBook, options);
+          } catch (error) {
+            debug5(`Syncing ${addressBook.displayName} failed with ${error}`);
+            account.addressBooks.splice(index, 1);
+          }
+        }));
+        return account;
+      });
+      basicSync2 = import_co4.default.wrap(function* (addressBook, options) {
+        let sync = isCollectionDirty(addressBook, options);
+        if (!sync) {
+          debug5("Local ctag matched remote! No need to sync :).");
+          return addressBook;
         }
-
-        debug('Local ctag matched remote! No need to sync :).');
-        return context$1$0.abrupt('return', addressBook);
-
-      case 4:
-
-        debug('ctag changed so we need to fetch stuffs.');
-        context$1$0.next = 7;
-        return listVCards(addressBook, options);
-
-      case 7:
-        addressBook.objects = context$1$0.sent;
-        return context$1$0.abrupt('return', addressBook);
-
-      case 9:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-var webdavSync = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(addressBook, options) {
-  var req, result;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        req = request.syncCollection({
-          props: [{ name: 'getetag', namespace: ns.DAV }, { name: 'address-data', namespace: ns.CARDDAV }],
+        debug5("ctag changed so we need to fetch stuffs.");
+        addressBook.objects = yield listVCards(addressBook, options);
+        return addressBook;
+      });
+      webdavSync2 = import_co4.default.wrap(function* (addressBook, options) {
+        var req = syncCollection3({
+          props: [
+            { name: "getetag", namespace: DAV },
+            { name: "address-data", namespace: CARDDAV }
+          ],
           syncLevel: 1,
           syncToken: addressBook.syncToken
         });
-        context$1$0.next = 3;
-        return options.xhr.send(req, addressBook.url, {
+        let result = yield options.xhr.send(req, addressBook.url, {
           sandbox: options.sandbox
         });
-
-      case 3:
-        result = context$1$0.sent;
-
-        // TODO(gareth): Handle creations and deletions.
-        result.responses.forEach(function (response) {
-          // Find the vcard that this response corresponds with.
-          var vcard = addressBook.objects.filter(function (object) {
-            return (0, _fuzzy_url_equals2['default'])(object.url, response.href);
+        result.responses.forEach((response) => {
+          let vcard = addressBook.objects.filter((object) => {
+            return fuzzyUrlEquals(object.url, response.href);
           })[0];
-
           if (!vcard) return;
-
           vcard.etag = response.props.getetag;
           vcard.addressData = response.props.addressData;
         });
-
         addressBook.syncToken = result.syncToken;
-        return context$1$0.abrupt('return', addressBook);
-
-      case 7:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-},{"./debug":6,"./fuzzy_url_equals":7,"./model":9,"./namespace":10,"./request":12,"./webdav":24,"co":26,"url":31}],6:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = debug;
-
-function debug(topic) {
-  return function (message) {
-    if (debug.enabled) {
-      console.log("[" + topic + "] " + message);
-    }
-  };
-}
-
-module.exports = exports["default"];
-},{}],7:[function(require,module,exports){
-'use strict';
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = fuzzyUrlEquals;
-
-function fuzzyUrlEquals(one, other) {
-  other = encodeURI(other);
-  return fuzzyIncludes(one, other) || fuzzyIncludes(other, one);
-}
-
-;
-
-function fuzzyIncludes(one, other) {
-  return one.indexOf(other) !== -1 || other.charAt(other.length - 1) === '/' && one.indexOf(other.slice(0, -1)) !== -1;
-}
-module.exports = exports['default'];
-},{}],8:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-function _interopExportWildcard(obj, defaults) { var newObj = defaults({}, obj); delete newObj['default']; return newObj; }
-
-function _defaults(obj, defaults) { var keys = Object.getOwnPropertyNames(defaults); for (var i = 0; i < keys.length; i++) { var key = keys[i]; var value = Object.getOwnPropertyDescriptor(defaults, key); if (value && value.configurable && obj[key] === undefined) { Object.defineProperty(obj, key, value); } } return obj; }
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _debug = require('./debug');
-
-var _debug2 = _interopRequireDefault(_debug);
-
-var _namespace = require('./namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-var _request = require('./request');
-
-var request = _interopRequireWildcard(_request);
-
-var _transport = require('./transport');
-
-var transport = _interopRequireWildcard(_transport);
-
-var _package = require('../package');
-
-Object.defineProperty(exports, 'version', {
-  enumerable: true,
-  get: function get() {
-    return _package.version;
-  }
-});
-
-var _accounts = require('./accounts');
-
-Object.defineProperty(exports, 'createAccount', {
-  enumerable: true,
-  get: function get() {
-    return _accounts.createAccount;
-  }
-});
-
-var _calendars = require('./calendars');
-
-_defaults(exports, _interopExportWildcard(_calendars, _defaults));
-
-var _client = require('./client');
-
-Object.defineProperty(exports, 'Client', {
-  enumerable: true,
-  get: function get() {
-    return _client.Client;
-  }
-});
-
-var _contacts = require('./contacts');
-
-_defaults(exports, _interopExportWildcard(_contacts, _defaults));
-
-var _model = require('./model');
-
-_defaults(exports, _interopExportWildcard(_model, _defaults));
-
-Object.defineProperty(exports, 'Request', {
-  enumerable: true,
-  get: function get() {
-    return _request.Request;
-  }
-});
-
-var _sandbox = require('./sandbox');
-
-Object.defineProperty(exports, 'Sandbox', {
-  enumerable: true,
-  get: function get() {
-    return _sandbox.Sandbox;
-  }
-});
-Object.defineProperty(exports, 'createSandbox', {
-  enumerable: true,
-  get: function get() {
-    return _sandbox.createSandbox;
-  }
-});
-exports.debug = _debug2['default'];
-exports.ns = ns;
-exports.request = request;
-exports.transport = transport;
-},{"../package":35,"./accounts":1,"./calendars":2,"./client":4,"./contacts":5,"./debug":6,"./model":9,"./namespace":10,"./request":12,"./sandbox":13,"./transport":23}],9:[function(require,module,exports){
-"use strict";
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-
-var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-var Account = function Account(options) {
-  _classCallCheck(this, Account);
-
-  Object.assign(this, {
-    server: null,
-    credentials: null,
-    rootUrl: null,
-    principalUrl: null,
-    homeUrl: null,
-    calendars: null,
-    addressBooks: null
-  }, options);
-}
-
-/**
- * Options:
- *   (String) username - username (perhaps email) for calendar user.
- *   (String) password - plaintext password for calendar user.
- *   (String) clientId - oauth client id.
- *   (String) clientSecret - oauth client secret.
- *   (String) authorizationCode - oauth code.
- *   (String) redirectUrl - oauth redirect url.
- *   (String) tokenUrl - oauth token url.
- *   (String) accessToken - oauth access token.
- *   (String) refreshToken - oauth refresh token.
- *   (Number) expiration - unix time for access token expiration.
- */
-;
-
-exports.Account = Account;
-
-var Credentials = function Credentials(options) {
-  _classCallCheck(this, Credentials);
-
-  Object.assign(this, {
-    username: null,
-    password: null,
-    clientId: null,
-    clientSecret: null,
-    authorizationCode: null,
-    redirectUrl: null,
-    tokenUrl: null,
-    accessToken: null,
-    refreshToken: null,
-    expiration: null
-  }, options);
-};
-
-exports.Credentials = Credentials;
-
-var DAVCollection = function DAVCollection(options) {
-  _classCallCheck(this, DAVCollection);
-
-  Object.assign(this, {
-    data: null,
-    objects: null,
-    account: null,
-    ctag: null,
-    description: null,
-    displayName: null,
-    reports: null,
-    resourcetype: null,
-    syncToken: null,
-    url: null
-  }, options);
-};
-
-exports.DAVCollection = DAVCollection;
-
-var AddressBook = (function (_DAVCollection) {
-  _inherits(AddressBook, _DAVCollection);
-
-  function AddressBook(options) {
-    _classCallCheck(this, AddressBook);
-
-    _get(Object.getPrototypeOf(AddressBook.prototype), "constructor", this).call(this, options);
-  }
-
-  return AddressBook;
-})(DAVCollection);
-
-exports.AddressBook = AddressBook;
-
-var Calendar = (function (_DAVCollection2) {
-  _inherits(Calendar, _DAVCollection2);
-
-  function Calendar(options) {
-    _classCallCheck(this, Calendar);
-
-    _get(Object.getPrototypeOf(Calendar.prototype), "constructor", this).call(this, options);
-    Object.assign(this, {
-      components: null,
-      timezone: null
-    }, options);
-  }
-
-  return Calendar;
-})(DAVCollection);
-
-exports.Calendar = Calendar;
-
-var DAVObject = function DAVObject(options) {
-  _classCallCheck(this, DAVObject);
-
-  Object.assign(this, {
-    data: null,
-    etag: null,
-    url: null
-  }, options);
-};
-
-exports.DAVObject = DAVObject;
-
-var CalendarObject = (function (_DAVObject) {
-  _inherits(CalendarObject, _DAVObject);
-
-  function CalendarObject(options) {
-    _classCallCheck(this, CalendarObject);
-
-    _get(Object.getPrototypeOf(CalendarObject.prototype), "constructor", this).call(this, options);
-    Object.assign(this, {
-      calendar: null,
-      calendarData: null
-    }, options);
-  }
-
-  return CalendarObject;
-})(DAVObject);
-
-exports.CalendarObject = CalendarObject;
-
-var VCard = (function (_DAVObject2) {
-  _inherits(VCard, _DAVObject2);
-
-  function VCard(options) {
-    _classCallCheck(this, VCard);
-
-    _get(Object.getPrototypeOf(VCard.prototype), "constructor", this).call(this, options);
-    Object.assign(this, {
-      addressBook: null,
-      addressData: null
-    }, options);
-  }
-
-  return VCard;
-})(DAVObject);
-
-exports.VCard = VCard;
-},{}],10:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-var CALENDAR_SERVER = 'http://calendarserver.org/ns/';
-exports.CALENDAR_SERVER = CALENDAR_SERVER;
-var CALDAV = 'urn:ietf:params:xml:ns:caldav';
-exports.CALDAV = CALDAV;
-var CARDDAV = 'urn:ietf:params:xml:ns:carddav';
-exports.CARDDAV = CARDDAV;
-var DAV = 'DAV:';
-exports.DAV = DAV;
-var OC = 'http://owncloud.org/ns';
-exports.OC = OC;
-},{}],11:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.multistatus = multistatus;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _camelize = require('./camelize');
-
-var _camelize2 = _interopRequireDefault(_camelize);
-
-var debug = require('./debug')('dav:parser');
-
-var DOMParser = require('xmldom').DOMParser;
-
-function multistatus(string) {
-  var parser = new DOMParser();
-  var doc = parser.parseFromString(string, 'text/xml');
-  var result = traverse.multistatus(child(doc, 'multistatus'));
-  debug('input:\n' + string + '\noutput:\n' + JSON.stringify(result) + '\n');
-  return result;
-}
-
-var traverse = {
-  // { response: [x, y, z] }
-  multistatus: function multistatus(node) {
-    return complex(node, { response: true });
-  },
-
-  // { propstat: [x, y, z] }
-  response: function response(node) {
-    return complex(node, { propstat: true, href: false });
-  },
-
-  // { prop: x }
-  propstat: function propstat(node) {
-    return complex(node, { prop: false });
-  },
-
-  // {
-  //   resourcetype: x
-  //   supportedCalendarComponentSet: y,
-  //   supportedReportSet: z
-  // }
-  prop: function prop(node) {
-    return complex(node, {
-      resourcetype: false,
-      supportedCalendarComponentSet: false,
-      supportedReportSet: false,
-      currentUserPrincipal: false,
-      groups: false,
-      invite: false
-    });
-  },
-
-  resourcetype: function resourcetype(node) {
-    return childNodes(node).map(function (childNode) {
-      return childNode.localName;
-    });
-  },
-
-  groups: function groups(node) {
-    return complex(node, { group: true }, 'group');
-  },
-  group: function group(node) {
-    return childNodes(node).map(function (childNode) {
-      return childNode.nodeValue;
-    });
-  },
-  invite: function invite(node) {
-    return complex(node, { user: true }, 'user');
-  },
-  user: function user(node) {
-    return complex(node, { href: false, access: false });
-  },
-  access: function access(node) {
-    return complex(node, {});
-  },
-  //access: node => {
-  //  return childNodes(node).map(childNode => childNode.localName);
-  //},
-
-  // [x, y, z]
-  supportedCalendarComponentSet: function supportedCalendarComponentSet(node) {
-    return complex(node, { comp: true }, 'comp');
-  },
-
-  // [x, y, z]
-  supportedReportSet: function supportedReportSet(node) {
-    return complex(node, { supportedReport: true }, 'supportedReport');
-  },
-
-  comp: function comp(node) {
-    return node.getAttribute('name');
-  },
-
-  // x
-  supportedReport: function supportedReport(node) {
-    return complex(node, { report: false }, 'report');
-  },
-
-  report: function report(node) {
-    return childNodes(node).map(function (childNode) {
-      return childNode.localName;
-    });
-  },
-
-  href: function href(node) {
-    return decodeURIComponent(childNodes(node)[0].nodeValue);
-  },
-
-  currentUserPrincipal: function currentUserPrincipal(node) {
-    return complex(node, { href: false }, 'href');
-  }
-};
-
-function complex(node, childspec, collapse) {
-  var result = {};
-  for (var key in childspec) {
-    if (childspec[key]) {
-      // Create array since we're expecting multiple.
-      result[key] = [];
-    }
-  }
-
-  childNodes(node).forEach(function (childNode) {
-    return traverseChild(node, childNode, childspec, result);
-  });
-
-  return maybeCollapse(result, childspec, collapse);
-}
-
-/**
- * Parse child childNode of node with childspec and write outcome to result.
- */
-function traverseChild(node, childNode, childspec, result) {
-  if (childNode.nodeType === 3 && /^\s+$/.test(childNode.nodeValue)) {
-    // Whitespace... nothing to do.
-    return;
-  }
-
-  var localName = (0, _camelize2['default'])(childNode.localName, '-');
-  if (!(localName in childspec)) {
-    debug('Unexpected node of type ' + localName + ' encountered while ' + 'parsing ' + node.localName + ' node!');
-    var value = childNode.textContent;
-    if (localName in result) {
-      if (!Array.isArray(result[camelCase])) {
-        // Since we've already encountered this node type and we haven't yet
-        // made an array for it, make an array now.
-        result[localName] = [result[localName]];
-      }
-
-      result[localName].push(value);
-      return;
-    }
-
-    // First time we're encountering this node.
-    result[localName] = value;
-    return;
-  }
-
-  var traversal = traverse[localName](childNode);
-  if (childspec[localName]) {
-    // Expect multiple.
-    result[localName].push(traversal);
-  } else {
-    // Expect single.
-    result[localName] = traversal;
-  }
-}
-
-function maybeCollapse(result, childspec, collapse) {
-  if (!collapse) {
-    return result;
-  }
-
-  if (!childspec[collapse]) {
-    return result[collapse];
-  }
-
-  // Collapse array.
-  return result[collapse].reduce(function (a, b) {
-    return a.concat(b);
-  }, []);
-}
-
-function childNodes(node) {
-  var result = node.childNodes;
-  if (!Array.isArray(result)) {
-    result = Array.prototype.slice.call(result);
-  }
-
-  return result;
-}
-
-function children(node, localName) {
-  return childNodes(node).filter(function (childNode) {
-    return childNode.localName === localName;
-  });
-}
-
-function child(node, localName) {
-  return children(node, localName)[0];
-}
-},{"./camelize":3,"./debug":6,"xmldom":32}],12:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.addressBookQuery = addressBookQuery;
-exports.basic = basic;
-exports.calendarQuery = calendarQuery;
-exports.collectionQuery = collectionQuery;
-exports.mkcol = mkcol;
-exports.proppatch = proppatch;
-exports.propfind = propfind;
-exports.syncCollection = syncCollection;
-exports.mergeProps = mergeProps;
-exports.getProps = getProps;
-exports.setRequestHeaders = setRequestHeaders;
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-var _parser = require('./parser');
-
-var _template = require('./template');
-
-var template = _interopRequireWildcard(_template);
-
-/**
- * Options:
- *
- *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) props - list of props to request.
- */
-
-function addressBookQuery(options) {
-  return collectionQuery(template.addressBookQuery({ props: options.props || [] }), { depth: options.depth });
-}
-
-/**
- * Options:
- *
- *   (String) data - put request body.
- *   (String) method - http method.
- *   (String) etag - cached calendar object etag.
- */
-
-function basic(options) {
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  return new Request({
-    method: options.method,
-    requestData: options.data,
-    transformRequest: transformRequest
-  });
-}
-
-/**
- * Options:
- *
- *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) filters - list of filters to send with request.
- *   (Array.<Object>) props - list of props to request.
- *   (String) timezone - VTIMEZONE calendar object.
- */
-
-function calendarQuery(options) {
-  return collectionQuery(template.calendarQuery({
-    props: options.props || [],
-    filters: options.filters || [],
-    timezone: options.timezone
-  }), {
-    depth: options.depth
-  });
-}
-
-function collectionQuery(requestData, options) {
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  function transformResponse(xhr) {
-    return (0, _parser.multistatus)(xhr.responseText).response.map(function (res) {
-      return { href: res.href, props: getProps(res.propstat) };
-    });
-  }
-
-  return new Request({
-    method: 'REPORT',
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
-}
-
-function mkcol(options) {
-  var requestData = template.mkcol({ props: options.props });
-
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  return new Request({
-    method: 'MKCOL',
-    requestData: requestData,
-    transformRequest: transformRequest
-  });
-}
-
-function proppatch(options) {
-  var requestData = template.proppatch({ props: options.props });
-
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  return new Request({
-    method: 'PROPPATCH',
-    requestData: requestData,
-    transformRequest: transformRequest
-  });
-}
-
-/**
- * Options:
- *
- *   (String) depth - optional value for Depth header.
- *   (Array.<Object>) props - list of props to request.
- */
-
-function propfind(options) {
-  var requestData = template.propfind({ props: options.props });
-
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  function transformResponse(xhr) {
-    var responses = (0, _parser.multistatus)(xhr.responseText).response.map(function (res) {
-      return { href: res.href, props: getProps(res.propstat) };
-    });
-
-    if (!options.mergeResponses) {
-      return responses;
-    }
-
-    // Merge the props.
-    var merged = mergeProps(responses.map(function (res) {
-      return res.props;
-    }));
-    var hrefs = responses.map(function (res) {
-      return res.href;
-    });
-    return { props: merged, hrefs: hrefs };
-  }
-
-  return new Request({
-    method: 'PROPFIND',
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
-}
-
-/**
- * Options:
- *
- *   (String) depth - option value for Depth header.
- *   (Array.<Object>) props - list of props to request.
- *   (Number) syncLevel - indicates scope of the sync report request.
- *   (String) syncToken - synchronization token provided by the server.
- */
-
-function syncCollection(options) {
-  var requestData = template.syncCollection({
-    props: options.props,
-    syncLevel: options.syncLevel,
-    syncToken: options.syncToken
-  });
-
-  function transformRequest(xhr) {
-    setRequestHeaders(xhr, options);
-  }
-
-  function transformResponse(xhr) {
-    var object = (0, _parser.multistatus)(xhr.responseText);
-    var responses = object.response.map(function (res) {
-      return { href: res.href, props: getProps(res.propstat) };
-    });
-
-    return { responses: responses, syncToken: object.syncToken };
-  }
-
-  return new Request({
-    method: 'REPORT',
-    requestData: requestData,
-    transformRequest: transformRequest,
-    transformResponse: transformResponse
-  });
-}
-
-var Request = function Request() {
-  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-  _classCallCheck(this, Request);
-
-  Object.assign(this, {
-    method: null,
-    requestData: null,
-    transformRequest: null,
-    transformResponse: null,
-    onerror: null
-  }, options);
-};
-
-exports.Request = Request;
-
-function getProp(propstat) {
-  if (/404/g.test(propstat.status)) {
-    return null;
-  }
-  if (/5\d{2}/g.test(propstat.status) || /4\d{2}/g.test(propstat.status)) {
-    throw new Error('Bad status on propstat: ' + propstat.status);
-  }
-
-  return 'prop' in propstat ? propstat.prop : null;
-}
-
-function mergeProps(props) {
-  return props.reduce(function (a, b) {
-    return Object.assign(a, b);
-  }, {});
-}
-
-/**
- * Map propstats to props.
- */
-
-function getProps(propstats) {
-  return mergeProps(propstats.map(getProp).filter(function (prop) {
-    return prop && typeof prop === 'object';
-  }));
-}
-
-function setRequestHeaders(request, options) {
-  if ('contentType' in options) {
-    request.setRequestHeader('Content-Type', options.contentType);
-  } else {
-    request.setRequestHeader('Content-Type', 'application/xml;charset=utf-8');
-  }
-
-  if ('depth' in options) {
-    request.setRequestHeader('Depth', options.depth);
-  }
-
-  if ('etag' in options) {
-    request.setRequestHeader('If-Match', options.etag);
-  }
-
-  if ('destination' in options) {
-    request.setRequestHeader('Destination', options.destination);
-  }
-
-  if ('overwrite' in options) {
-    request.setRequestHeader('Overwrite', options.overwrite);
-  }
-}
-},{"./parser":11,"./template":17}],13:[function(require,module,exports){
-/**
- * @fileoverview Group requests together and then abort as a group.
- *
- * var sandbox = new dav.Sandbox();
- * return Promise.all([
- *   dav.createEvent(event, { sandbox: sandbox }),
- *   dav.deleteEvent(other, { sandbox: sandbox })
- * ])
- * .catch(function() {
- *   // Something went wrong so abort all requests.
- *   sandbox.abort;
- * });
- */
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-exports.createSandbox = createSandbox;
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-var debug = require('./debug')('dav:sandbox');
-
-var Sandbox = (function () {
-  function Sandbox() {
-    _classCallCheck(this, Sandbox);
-
-    this.requestList = [];
-  }
-
-  _createClass(Sandbox, [{
-    key: 'add',
-    value: function add(request) {
-      debug('Adding request to sandbox.');
-      this.requestList.push(request);
-    }
-  }, {
-    key: 'abort',
-    value: function abort() {
-      debug('Aborting sandboxed requests.');
-      this.requestList.forEach(function (request) {
-        return request.abort();
+        return addressBook;
       });
     }
-  }]);
-
-  return Sandbox;
-})();
-
-exports.Sandbox = Sandbox;
-
-function createSandbox() {
-  return new Sandbox();
-}
-},{"./debug":6}],14:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = addressBookQuery;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function addressBookQuery(object) {
-  return '<card:addressbook-query xmlns:card="urn:ietf:params:xml:ns:carddav"\n                          xmlns:d="DAV:">\n    <d:prop>\n      ' + object.props.map(_prop2['default']) + '\n    </d:prop>\n    <!-- According to http://stackoverflow.com/questions/23742568/google-carddav-api-addressbook-multiget-returns-400-bad-request,\n         Google\'s CardDAV server requires a filter element. I don\'t think all addressbook-query calls need a filter in the spec though? -->\n  </card:addressbook-query>';
-}
-
-module.exports = exports['default'];
-},{"./prop":19}],15:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = calendarQuery;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _filter = require('./filter');
-
-var _filter2 = _interopRequireDefault(_filter);
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function calendarQuery(object) {
-  return '<c:calendar-query xmlns:c="urn:ietf:params:xml:ns:caldav"\n                    xmlns:cs="http://calendarserver.org/ns/"\n                    xmlns:d="DAV:">\n    <d:prop>\n      ' + object.props.map(_prop2['default']) + '\n    </d:prop>\n    <c:filter>\n      ' + object.filters.map(_filter2['default']) + '\n    </c:filter>\n    ' + (object.timezone ? '<c:timezone>' + object.timezone + '</c:timezone>' : '') + '\n  </c:calendar-query>';
-}
-
-module.exports = exports['default'];
-},{"./filter":16,"./prop":19}],16:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = filter;
-
-function filter(item) {
-  if (!item.children || !item.children.length) {
-    return '<c:' + item.type + ' ' + formatAttrs(item.attrs) + '/>';
-  }
-
-  var children = item.children.map(filter);
-  return '<c:' + item.type + ' ' + formatAttrs(item.attrs) + '>\n            ' + children + '\n          </c:' + item.type + '>';
-}
-
-function formatAttrs(attrs) {
-  if (typeof attrs !== 'object') {
-    return '';
-  }
-
-  return Object.keys(attrs).map(function (attr) {
-    return attr + '="' + attrs[attr] + '"';
-  }).join(' ');
-}
-module.exports = exports['default'];
-},{}],17:[function(require,module,exports){
-'use strict';
-
-exports.addressBookQuery = require('./address_book_query');
-exports.calendarQuery = require('./calendar_query');
-exports.propfind = require('./propfind');
-exports.syncCollection = require('./sync_collection');
-exports.mkcol = require('./mkcol');
-exports.proppatch = require('./proppatch');
-},{"./address_book_query":14,"./calendar_query":15,"./mkcol":18,"./propfind":20,"./proppatch":21,"./sync_collection":22}],18:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = mkcol;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function mkcol(object) {
-  return '<d:mkcol xmlns:c="urn:ietf:params:xml:ns:caldav"\n              xmlns:card="urn:ietf:params:xml:ns:carddav"\n              xmlns:cs="http://calendarserver.org/ns/"\n              xmlns:d="DAV:">\n    <d:set>\n      <d:prop>\n        ' + object.props.map(_prop2['default']) + '\n      </d:prop>\n    </d:set>\n  </d:mkcol>';
-}
-
-module.exports = exports['default'];
-},{"./prop":19}],19:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = prop;
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-var _namespace = require('../namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-/**
- * @param {Object} filter looks like
- *
- *     {
- *       type: 'comp-filter',
- *       attrs: {
- *         name: 'VCALENDAR'
- *       }
- *     }
- *
- * Or maybe
- *
- *     {
- *       type: 'time-range',
- *       attrs: {
- *         start: '20060104T000000Z',
- *         end: '20060105T000000Z'
- *       }
- *     }
- *
- * You can nest them like so:
- *
- *     {
- *       type: 'comp-filter',
- *       attrs: { name: 'VCALENDAR' },
- *       children: [{
- *         type: 'comp-filter',
- *         attrs: { name: 'VEVENT' },
- *         children: [{
- *           type: 'time-range',
- *           attrs: { start: '20060104T000000Z', end: '20060105T000000Z' }
- *         }]
- *       }]
- *     }
- */
-
-function prop(item) {
-  if (!item.children || !item.children.length) {
-    if (typeof item.value === "undefined") {
-      return '<' + xmlnsPrefix(item.namespace) + ':' + item.name + ' />';
-    }
-    return '<' + xmlnsPrefix(item.namespace) + ':' + item.name + '>' + item.value + '</' + xmlnsPrefix(item.namespace) + ':' + item.name + '>';
-  }
-
-  var children = item.children.map(prop);
-  return '<' + xmlnsPrefix(item.namespace) + ':' + item.name + '>\n            ' + children + '\n          </' + xmlnsPrefix(item.namespace) + ':' + item.name + '>';
-}
-
-function xmlnsPrefix(namespace) {
-  switch (namespace) {
-    case ns.DAV:
-      return 'd';
-    case ns.CALENDAR_SERVER:
-      return 'cs';
-    case ns.CALDAV:
-      return 'c';
-    case ns.CARDDAV:
-      return 'card';
-    case ns.OC:
-      return 'oc';
-    default:
-      throw new Error('Unrecognized xmlns ' + namespace);
-  }
-}
-module.exports = exports['default'];
-},{"../namespace":10}],20:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = propfind;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function propfind(object) {
-  return '<d:propfind xmlns:c="urn:ietf:params:xml:ns:caldav"\n              xmlns:card="urn:ietf:params:xml:ns:carddav"\n              xmlns:cs="http://calendarserver.org/ns/"\n              xmlns:oc="http://owncloud.org/ns"\n              xmlns:d="DAV:">\n    <d:prop>\n      ' + object.props.map(_prop2['default']) + '\n    </d:prop>\n  </d:propfind>';
-}
-
-module.exports = exports['default'];
-},{"./prop":19}],21:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = proppatch;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function proppatch(object) {
-  return '<d:propertyupdate xmlns:c="urn:ietf:params:xml:ns:caldav"\n              xmlns:card="urn:ietf:params:xml:ns:carddav"\n              xmlns:cs="http://calendarserver.org/ns/"\n              xmlns:d="DAV:">\n    <d:set>\n      <d:prop>\n        ' + object.props.map(_prop2['default']) + '\n      </d:prop>\n    </d:set>\n  </d:propertyupdate>';
-}
-
-module.exports = exports['default'];
-},{"./prop":19}],22:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports['default'] = syncCollection;
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _prop = require('./prop');
-
-var _prop2 = _interopRequireDefault(_prop);
-
-function syncCollection(object) {
-  return '<d:sync-collection xmlns:c="urn:ietf:params:xml:ns:caldav"\n                     xmlns:card="urn:ietf:params:xml:ns:carddav"\n                     xmlns:d="DAV:">\n    <d:sync-level>' + object.syncLevel + '</d:sync-level>\n    <d:sync-token>' + object.syncToken + '</d:sync-token>\n    <d:prop>\n      ' + object.props.map(_prop2['default']) + '\n    </d:prop>\n  </d:sync-collection>';
-}
-
-module.exports = exports['default'];
-},{"./prop":19}],23:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-
-var _get = function get(_x2, _x3, _x4) { var _again = true; _function: while (_again) { var object = _x2, property = _x3, receiver = _x4; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x2 = parent; _x3 = property; _x4 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-var _co = require('co');
-
-var _co2 = _interopRequireDefault(_co);
-
-var _querystring = require('querystring');
-
-var _querystring2 = _interopRequireDefault(_querystring);
-
-var _xmlhttprequest = require('./xmlhttprequest');
-
-var _xmlhttprequest2 = _interopRequireDefault(_xmlhttprequest);
-
-var Transport = (function () {
-  /**
-   * @param {dav.Credentials} credentials user authorization.
-   */
-
-  function Transport(credentials) {
-    _classCallCheck(this, Transport);
-
-    this.credentials = credentials || null;
-  }
-
-  /**
-   * @param {dav.Request} request object with request info.
-   * @return {Promise} a promise that will be resolved with an xhr request after
-   *     its readyState is 4 or the result of applying an optional request
-   *     `transformResponse` function to the xhr object after its readyState is 4.
-   *
-   * Options:
-   *
-   *   (Object) sandbox - optional request sandbox.
-   */
-
-  _createClass(Transport, [{
-    key: 'send',
-    value: function send() {}
-  }]);
-
-  return Transport;
-})();
-
-exports.Transport = Transport;
-
-var Basic = (function (_Transport) {
-  _inherits(Basic, _Transport);
-
-  /**
-   * @param {dav.Credentials} credentials user authorization.
-   */
-
-  function Basic(credentials) {
-    _classCallCheck(this, Basic);
-
-    _get(Object.getPrototypeOf(Basic.prototype), 'constructor', this).call(this, credentials);
-  }
-
-  /**
-   * @param {dav.Credentials} credentials user authorization.
-   */
-
-  _createClass(Basic, [{
-    key: 'send',
-    value: function send(request, url, options) {
-      return (0, _co2['default'])(regeneratorRuntime.mark(function callee$2$0() {
-        var sandbox, transformRequest, transformResponse, onerror, xhr, result;
-        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-          while (1) switch (context$3$0.prev = context$3$0.next) {
-            case 0:
-              sandbox = options && options.sandbox;
-              transformRequest = request.transformRequest;
-              transformResponse = request.transformResponse;
-              onerror = request.onerror;
-              xhr = new _xmlhttprequest2['default']();
-
-              if (sandbox) sandbox.add(xhr);
-              xhr.open(request.method, url, true, /* async */
-              this.credentials.username, this.credentials.password);
-
-              if (transformRequest) transformRequest(xhr);
-
-              result = undefined;
-              context$3$0.prev = 9;
-
-              xhr.setRequestHeader('requesttoken', oc_requesttoken);
-              context$3$0.next = 13;
-              return xhr.send(request.requestData);
-
-            case 13:
-              result = transformResponse ? transformResponse(xhr) : xhr;
-              context$3$0.next = 20;
-              break;
-
-            case 16:
-              context$3$0.prev = 16;
-              context$3$0.t0 = context$3$0['catch'](9);
-
-              if (onerror) onerror(context$3$0.t0);
-              throw context$3$0.t0;
-
-            case 20:
-              return context$3$0.abrupt('return', result);
-
-            case 21:
-            case 'end':
-              return context$3$0.stop();
-          }
-        }, callee$2$0, this, [[9, 16]]);
-      }).bind(this));
-    }
-  }]);
-
-  return Basic;
-})(Transport);
-
-exports.Basic = Basic;
-
-var OAuth2 = (function (_Transport2) {
-  _inherits(OAuth2, _Transport2);
-
-  function OAuth2(credentials) {
-    _classCallCheck(this, OAuth2);
-
-    _get(Object.getPrototypeOf(OAuth2.prototype), 'constructor', this).call(this, credentials);
-  }
-
-  /**
-   * @return {Promise} promise that will resolve with access token.
-   */
-
-  _createClass(OAuth2, [{
-    key: 'send',
-    value: function send(request, url) {
-      var options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
-
-      return (0, _co2['default'])(regeneratorRuntime.mark(function callee$2$0() {
-        var sandbox, transformRequest, transformResponse, onerror, result, xhr, token;
-        return regeneratorRuntime.wrap(function callee$2$0$(context$3$0) {
-          while (1) switch (context$3$0.prev = context$3$0.next) {
-            case 0:
-              sandbox = options.sandbox;
-              transformRequest = request.transformRequest;
-              transformResponse = request.transformResponse;
-              onerror = request.onerror;
-
-              if (!('retry' in options)) options.retry = true;
-
-              result = undefined, xhr = undefined;
-              context$3$0.prev = 6;
-              context$3$0.next = 9;
-              return access(this.credentials, options);
-
-            case 9:
-              token = context$3$0.sent;
-
-              xhr = new _xmlhttprequest2['default']();
-              if (sandbox) sandbox.add(xhr);
-              xhr.open(request.method, url, true /* async */);
-              xhr.setRequestHeader('Authorization', 'Bearer ' + token);
-              if (transformRequest) transformRequest(xhr);
-              xhr.setRequestHeader('requesttoken', oc_requesttoken);
-              context$3$0.next = 18;
-              return xhr.send(request.requestData);
-
-            case 18:
-              result = transformResponse ? transformResponse(xhr) : xhr;
-              context$3$0.next = 29;
-              break;
-
-            case 21:
-              context$3$0.prev = 21;
-              context$3$0.t0 = context$3$0['catch'](6);
-
-              if (!(options.retry && xhr.status === 401)) {
-                context$3$0.next = 27;
-                break;
-              }
-
-              // Force expiration.
-              this.credentials.expiration = 0;
-              // Retry once at most.
-              options.retry = false;
-              return context$3$0.abrupt('return', this.send(request, url, options));
-
-            case 27:
-
-              if (onerror) onerror(context$3$0.t0);
-              throw context$3$0.t0;
-
-            case 29:
-              return context$3$0.abrupt('return', result);
-
-            case 30:
-            case 'end':
-              return context$3$0.stop();
-          }
-        }, callee$2$0, this, [[6, 21]]);
-      }).bind(this));
-    }
-  }]);
-
-  return OAuth2;
-})(Transport);
-
-exports.OAuth2 = OAuth2;
-function access(credentials, options) {
-  if (!credentials.accessToken) {
-    return getAccessToken(credentials, options);
-  }
-
-  if (credentials.refreshToken && isExpired(credentials)) {
-    return refreshAccessToken(credentials, options);
-  }
-
-  return Promise.resolve(credentials.accessToken);
-}
-
-function isExpired(credentials) {
-  return typeof credentials.expiration === 'number' && Date.now() > credentials.expiration;
-}
-
-var getAccessToken = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(credentials, options) {
-  var sandbox, xhr, data, now, response;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        sandbox = options.sandbox;
-        xhr = new _xmlhttprequest2['default']();
-
-        if (sandbox) sandbox.add(xhr);
-        xhr.open('POST', credentials.tokenUrl, true /* async */);
-        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-
-        data = _querystring2['default'].stringify({
-          code: credentials.authorizationCode,
-          redirect_uri: credentials.redirectUrl,
-          client_id: credentials.clientId,
-          client_secret: credentials.clientSecret,
-          grant_type: 'authorization_code'
-        });
-        now = Date.now();
-        context$1$0.next = 9;
-        return xhr.send(data);
-
-      case 9:
-        response = JSON.parse(xhr.responseText);
-
-        credentials.accessToken = response.access_token;
-        credentials.refreshToken = 'refresh_token' in response ? response.refresh_token : null;
-        credentials.expiration = 'expires_in' in response ? now + response.expires_in : null;
-
-        return context$1$0.abrupt('return', response.access_token);
-
-      case 14:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-var refreshAccessToken = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(credentials, options) {
-  var sandbox, xhr, data, now, response;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        sandbox = options.sandbox;
-        xhr = new _xmlhttprequest2['default']();
-
-        if (sandbox) sandbox.add(xhr);
-        xhr.open('POST', credentials.tokenUrl, true /* async */);
-        xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-
-        data = _querystring2['default'].stringify({
-          client_id: credentials.clientId,
-          client_secret: credentials.clientSecret,
-          refresh_token: credentials.refreshToken,
-          grant_type: 'refresh_token'
-        });
-        now = Date.now();
-        context$1$0.next = 9;
-        return xhr.send(data);
-
-      case 9:
-        response = JSON.parse(xhr.responseText);
-
-        credentials.accessToken = response.access_token;
-        credentials.expiration = 'expires_in' in response ? now + response.expires_in : null;
-
-        return context$1$0.abrupt('return', response.access_token);
-
-      case 13:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-},{"./xmlhttprequest":25,"co":26,"querystring":30}],24:[function(require,module,exports){
-'use strict';
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.createObject = createObject;
-exports.updateObject = updateObject;
-exports.deleteObject = deleteObject;
-exports.syncCollection = syncCollection;
-exports.updateProperties = updateProperties;
-exports.createCollection = createCollection;
-exports.deleteCollection = deleteCollection;
-exports.moveCollection = moveCollection;
-
-function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj['default'] = obj; return newObj; } }
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-var _co = require('co');
-
-var _co2 = _interopRequireDefault(_co);
-
-var _fuzzy_url_equals = require('./fuzzy_url_equals');
-
-var _fuzzy_url_equals2 = _interopRequireDefault(_fuzzy_url_equals);
-
-var _namespace = require('./namespace');
-
-var ns = _interopRequireWildcard(_namespace);
-
-var _request = require('./request');
-
-var request = _interopRequireWildcard(_request);
-
-var debug = require('./debug')('dav:webdav');
-
-/**
- * @param {String} objectUrl url for webdav object.
- * @param {String} objectData webdav object data.
- */
-
-function createObject(objectUrl, objectData, options) {
-  // ugly (breaks calendar), but we will get rid of the lib anyway... hopefully... soon...
-  var req = request.basic({ method: 'PUT', data: objectData, contentType: 'text/vcard;charset=utf-8' });
-  return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
-}
-
-function updateObject(objectUrl, objectData, etag, options) {
-  // ugly (breaks calendar), but we will get rid of the lib anyway... hopefully... soon...
-  var req = request.basic({ method: 'PUT', data: objectData, etag: etag, contentType: 'text/vcard;charset=utf-8' });
-  return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
-}
-
-function deleteObject(objectUrl, etag, options) {
-  var req = request.basic({ method: 'DELETE', etag: etag });
-  return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
-}
-
-function syncCollection(collection, options) {
-  var syncMethod = undefined;
-  if ('syncMethod' in options) {
-    syncMethod = options.syncMethod;
-  } else if (collection.reports && collection.reports.indexOf('syncCollection') !== -1) {
-    syncMethod = 'webdav';
-  } else {
-    syncMethod = 'basic';
-  }
-
-  if (syncMethod === 'webdav') {
-    debug('rfc 6578 sync.');
-    return options.webdavSync(collection, options);
-  } else {
-    debug('basic sync.');
-    return options.basicSync(collection, options);
-  }
-}
-
-function updateProperties(objectUrl, options) {
-  var req = request.proppatch({
-    props: options.props
   });
-  return options.xhr.send(req, objectUrl, { sandbox: options.sandbox });
-}
 
-function createCollection(collectionUrl, options) {
-  var req = request.mkcol({
-    props: options.props
-  });
-  return options.xhr.send(req, collectionUrl, { sandbox: options.sandbox });
-}
-
-function deleteCollection(collectionUrl, options) {
-  var req = request.basic({ method: 'DELETE' });
-  return options.xhr.send(req, collectionUrl, { sandbox: options.sandbox });
-}
-
-function moveCollection(collectionUrl, options) {
-  var req = request.basic({ method: 'MOVE', overwrite: 'F', destination: options.destination, data: objectData });
-  return options.xhr.send(req, collectionUrl, { sandbox: options.sandbox });
-}
-
-/**
- * @param {dav.DAVCollection} collection to fetch report set for.
- */
-var supportedReportSet = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(collection, options) {
-  var req, response;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        debug('Checking supported report set for collection at ' + collection.url);
-        req = request.propfind({
-          props: [{ name: 'supported-report-set', namespace: ns.DAV }],
-          depth: 1,
+  // lib/accounts.js
+  var require_accounts = __commonJS({
+    "lib/accounts.js"(exports) {
+      var import_co5 = __toESM(require_co());
+      var import_url4 = __toESM(require_url());
+      init_calendars();
+      init_contacts();
+      init_fuzzy_url_equals();
+      init_model();
+      init_namespace();
+      init_request();
+      var debug8 = require_debug()("dav:accounts");
+      var defaults = {
+        accountType: "caldav",
+        loadCollections: true,
+        loadObjects: false
+      };
+      var serviceDiscovery = import_co5.default.wrap(function* (account, options) {
+        debug8("Attempt service discovery.");
+        let endpoint = import_url4.default.parse(account.server);
+        endpoint.protocol = endpoint.protocol || "http";
+        let uri = import_url4.default.format({
+          protocol: endpoint.protocol,
+          host: endpoint.host,
+          pathname: !options.useProvidedPath ? "/.well-known/" + options.accountType : endpoint.pathname
+        });
+        let req = basic({ method: "GET" });
+        try {
+          let xhr = yield options.xhr.send(req, uri, { sandbox: options.sandbox });
+          if (xhr.status >= 300 && xhr.status < 400) {
+            let location = xhr.getResponseHeader("Location");
+            if (typeof location === "string" && location.length) {
+              debug8(`Discovery redirected to ${location}`);
+              return import_url4.default.format({
+                protocol: endpoint.protocol,
+                host: endpoint.host,
+                pathname: location
+              });
+            }
+          }
+        } catch (error) {
+          debug8("Discovery failed... failover to the provided url");
+        }
+        return endpoint.href;
+      });
+      var principalUrl = import_co5.default.wrap(function* (account, options) {
+        debug8(`Fetch principal url from context path ${account.rootUrl}.`);
+        let req = propfind3({
+          props: [{ name: "current-user-principal", namespace: DAV }],
+          depth: 0,
           mergeResponses: true
         });
-        context$1$0.next = 4;
-        return options.xhr.send(req, collection.url, {
+        let res = yield options.xhr.send(req, account.rootUrl, {
           sandbox: options.sandbox
         });
-
-      case 4:
-        response = context$1$0.sent;
-        return context$1$0.abrupt('return', response.props.supportedReportSet);
-
-      case 6:
-      case 'end':
-        return context$1$0.stop();
-    }
-  }, callee$0$0, this);
-}));
-
-exports.supportedReportSet = supportedReportSet;
-var isCollectionDirty = _co2['default'].wrap(regeneratorRuntime.mark(function callee$0$0(collection, options) {
-  var req, responses, response;
-  return regeneratorRuntime.wrap(function callee$0$0$(context$1$0) {
-    while (1) switch (context$1$0.prev = context$1$0.next) {
-      case 0:
-        if (collection.ctag) {
-          context$1$0.next = 3;
-          break;
+        let container = res.props;
+        debug8(`Received principal: ${container.currentUserPrincipal}`);
+        return import_url4.default.resolve(account.rootUrl, container.currentUserPrincipal);
+      });
+      var homeUrl = import_co5.default.wrap(function* (account, options) {
+        debug8(`Fetch home url from principal url ${account.principalUrl}.`);
+        let prop2;
+        if (options.accountType === "caldav") {
+          prop2 = { name: "calendar-home-set", namespace: CALDAV };
+        } else if (options.accountType === "carddav") {
+          prop2 = { name: "addressbook-home-set", namespace: CARDDAV };
         }
-
-        debug('Missing ctag.');
-        return context$1$0.abrupt('return', false);
-
-      case 3:
-
-        debug('Fetch remote getctag prop.');
-        req = request.propfind({
-          props: [{ name: 'getctag', namespace: ns.CALENDAR_SERVER }],
-          depth: 0
-        });
-        context$1$0.next = 7;
-        return options.xhr.send(req, collection.account.homeUrl, {
+        var req = propfind3({ props: [prop2] });
+        let responses = yield options.xhr.send(req, account.principalUrl, {
           sandbox: options.sandbox
         });
-
-      case 7:
-        responses = context$1$0.sent;
-        response = responses.filter(function (response) {
-          // Find the response that corresponds to the parameter collection.
-          return (0, _fuzzy_url_equals2['default'])(collection.url, response.href);
-        })[0];
-
-        if (response) {
-          context$1$0.next = 11;
-          break;
+        let response = responses.find((response2) => {
+          return fuzzyUrlEquals(account.principalUrl, response2.href);
+        });
+        let container = response.props;
+        let href;
+        if (options.accountType === "caldav") {
+          debug8(`Received home: ${container.calendarHomeSet}`);
+          href = container.calendarHomeSet;
+        } else if (options.accountType === "carddav") {
+          debug8(`Received home: ${container.addressbookHomeSet}`);
+          href = container.addressbookHomeSet;
         }
-
-        throw new Error('Could not find collection on remote. Was it deleted?');
-
-      case 11:
-
-        debug('Check whether cached ctag matches remote.');
-        return context$1$0.abrupt('return', collection.ctag !== response.props.getctag);
-
-      case 13:
-      case 'end':
-        return context$1$0.stop();
+        return import_url4.default.resolve(account.rootUrl, href);
+      });
+      exports.createAccount = import_co5.default.wrap(function* (options) {
+        options = Object.assign({}, defaults, options);
+        if (typeof options.loadObjects !== "boolean") {
+          options.loadObjects = options.loadCollections;
+        }
+        let account = new Account({
+          server: options.server,
+          credentials: options.xhr.credentials
+        });
+        account.rootUrl = yield serviceDiscovery(account, options);
+        account.principalUrl = yield principalUrl(account, options);
+        account.homeUrl = yield homeUrl(account, options);
+        if (!options.loadCollections) {
+          return account;
+        }
+        let key, loadCollections, loadObjects;
+        if (options.accountType === "caldav") {
+          key = "calendars";
+          loadCollections = listCalendars;
+          loadObjects = listCalendarObjects;
+        } else if (options.accountType === "carddav") {
+          key = "addressBooks";
+          loadCollections = listAddressBooks;
+          loadObjects = listVCards;
+        }
+        var collections = yield loadCollections(account, options);
+        account[key] = collections;
+        if (!options.loadObjects) {
+          return account;
+        }
+        yield collections.map(import_co5.default.wrap(function* (collection) {
+          try {
+            collection.objects = yield loadObjects(collection, options);
+          } catch (error) {
+            collection.error = error;
+          }
+        }));
+        account[key] = account[key].filter(function(collection) {
+          return !collection.error;
+        });
+        return account;
+      });
     }
-  }, callee$0$0, this);
-}));
-exports.isCollectionDirty = isCollectionDirty;
-},{"./debug":6,"./fuzzy_url_equals":7,"./namespace":10,"./request":12,"co":26}],25:[function(require,module,exports){
-'use strict';
+  });
 
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
+  // lib/index.js
+  var index_exports = {};
+  __export(index_exports, {
+    Account: () => Account,
+    AddressBook: () => AddressBook,
+    Calendar: () => Calendar,
+    CalendarObject: () => CalendarObject,
+    Client: () => Client,
+    Credentials: () => Credentials,
+    DAVCollection: () => DAVCollection,
+    DAVObject: () => DAVObject,
+    Request: () => Request,
+    Sandbox: () => Sandbox,
+    VCard: () => VCard,
+    createAccount: () => import_accounts.createAccount,
+    createAddressBook: () => createAddressBook,
+    createCalendarObject: () => createCalendarObject,
+    createCard: () => createCard,
+    createSandbox: () => createSandbox,
+    debug: () => import_debug.default,
+    deleteAddressBook: () => deleteAddressBook,
+    deleteCalendarObject: () => deleteCalendarObject,
+    deleteCard: () => deleteCard,
+    getAddressBook: () => getAddressBook,
+    listAddressBooks: () => listAddressBooks,
+    listCalendarObjects: () => listCalendarObjects,
+    listCalendars: () => listCalendars,
+    listVCards: () => listVCards,
+    ns: () => namespace_exports,
+    renameAddressBook: () => renameAddressBook,
+    request: () => request_exports,
+    syncAddressBook: () => syncAddressBook,
+    syncCaldavAccount: () => syncCaldavAccount,
+    syncCalendar: () => syncCalendar,
+    syncCarddavAccount: () => syncCarddavAccount,
+    transport: () => transport_exports,
+    updateCalendarObject: () => updateCalendarObject,
+    updateCard: () => updateCard,
+    version: () => version
+  });
+  var import_debug = __toESM(require_debug());
+  init_namespace();
+  init_request();
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+  // lib/transport.js
+  var transport_exports = {};
+  __export(transport_exports, {
+    Basic: () => Basic,
+    OAuth2: () => OAuth2,
+    Transport: () => Transport
+  });
+  var import_co = __toESM(require_co());
+  var import_querystring = __toESM(require_querystring());
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-var debug = require('./debug')('dav:xmlhttprequest');
-
-var Native = undefined;
-if (typeof self !== 'undefined' && 'XMLHttpRequest' in self) {
-  Native = self.XMLHttpRequest;
-} else {
-  // Trick browserify into not loading XMLHttpRequest polyfill
-  // since it is available in the platform (including web workers)
-  Native = require(false || 'xmlhttprequest').XMLHttpRequest;
-}
-
-/**
- * @fileoverview Promise wrapper around native xhr api.
- */
-
-var XMLHttpRequest = (function () {
-  function XMLHttpRequest(options) {
-    var _this = this;
-
-    _classCallCheck(this, XMLHttpRequest);
-
-    this.request = new Native(options);
-    this.sandbox = null;
-
-    /* readwrite */
-    ['response', 'responseText', 'responseType', 'responseXML', 'timeout', 'upload', 'withCredentials'].forEach(function (attribute) {
-      Object.defineProperty(_this, attribute, {
-        get: function get() {
-          return this.request[attribute];
-        },
-        set: function set(value) {
-          this.request[attribute] = value;
-        }
-      });
-    });
-
-    /* readonly */
-    ['status', 'statusText'].forEach(function (attribute) {
-      Object.defineProperty(_this, attribute, {
-        get: function get() {
-          return this.request[attribute];
-        }
-      });
-    });
+  // lib/xmlhttprequest.js
+  var debug2 = require_debug()("dav:xmlhttprequest");
+  var Native;
+  if (typeof self !== "undefined" && "XMLHttpRequest" in self) {
+    Native = self.XMLHttpRequest;
+  } else {
+    Native = require_xmlhttprequest().XMLHttpRequest;
   }
-
-  _createClass(XMLHttpRequest, [{
-    key: 'abort',
-    value: function abort() {
-      return this._callNative('abort', arguments);
+  var XMLHttpRequest = class {
+    constructor(options) {
+      this.request = new Native(options);
+      this.sandbox = null;
+      [
+        "response",
+        "responseText",
+        "responseType",
+        "responseXML",
+        "timeout",
+        "upload",
+        "withCredentials"
+      ].forEach((attribute) => {
+        Object.defineProperty(this, attribute, {
+          get: function() {
+            return this.request[attribute];
+          },
+          set: function(value) {
+            this.request[attribute] = value;
+          }
+        });
+      });
+      [
+        "status",
+        "statusText"
+      ].forEach((attribute) => {
+        Object.defineProperty(this, attribute, {
+          get: function() {
+            return this.request[attribute];
+          }
+        });
+      });
     }
-  }, {
-    key: 'getAllResponseHeaders',
-    value: function getAllResponseHeaders() {
-      return this._callNative('getAllResponseHeaders', arguments);
+    abort() {
+      return this._callNative("abort", arguments);
     }
-  }, {
-    key: 'getResponseHeader',
-    value: function getResponseHeader() {
-      return this._callNative('getResponseHeader', arguments);
+    getAllResponseHeaders() {
+      return this._callNative("getAllResponseHeaders", arguments);
     }
-  }, {
-    key: 'open',
-    value: function open() {
-      return this._callNative('open', arguments);
+    getResponseHeader() {
+      return this._callNative("getResponseHeader", arguments);
     }
-  }, {
-    key: 'overrideMimeType',
-    value: function overrideMimeType() {
-      return this._callNative('overrideMimeType', arguments);
+    open() {
+      return this._callNative("open", arguments);
     }
-  }, {
-    key: 'setRequestHeader',
-    value: function setRequestHeader() {
-      return this._callNative('setRequestHeader', arguments);
+    overrideMimeType() {
+      return this._callNative("overrideMimeType", arguments);
     }
-  }, {
-    key: 'send',
-    value: function send(data) {
-      debug('Sending request data: ' + data);
+    setRequestHeader() {
+      return this._callNative("setRequestHeader", arguments);
+    }
+    send(data) {
+      debug2(`Sending request data: ${data}`);
       if (this.sandbox) this.sandbox.add(this);
-      var request = this.request;
+      let request = this.request;
       request.send(data);
-      return new Promise(function (resolve, reject) {
-        request.onreadystatechange = function () {
-          if (request.readyState !== 4 /* done */) {
-              return;
-            }
-
+      return new Promise(function(resolve, reject) {
+        request.onreadystatechange = function() {
+          if (request.readyState !== 4) {
+            return;
+          }
           if (request.status < 200 || request.status >= 400) {
             return reject(request);
           }
-
           return resolve(request.responseText);
         };
-
-        request.ontimeout = function () {
-          reject(new Error('Request timed out after ' + request.timeout + ' ms'));
+        request.ontimeout = function() {
+          reject(new Error(`Request timed out after ${request.timeout} ms`));
         };
       });
     }
-  }, {
-    key: '_callNative',
-    value: function _callNative(method, args) {
+    _callNative(method, args) {
       return this.request[method].apply(this.request, args);
     }
-  }]);
+  };
 
-  return XMLHttpRequest;
-})();
-
-exports['default'] = XMLHttpRequest;
-module.exports = exports['default'];
-},{"./debug":6}],26:[function(require,module,exports){
-
-/**
- * slice() reference.
- */
-
-var slice = Array.prototype.slice;
-
-/**
- * Expose `co`.
- */
-
-module.exports = co['default'] = co.co = co;
-
-/**
- * Wrap the given generator `fn` into a
- * function that returns a promise.
- * This is a separate function so that
- * every `co()` call doesn't create a new,
- * unnecessary closure.
- *
- * @param {GeneratorFunction} fn
- * @return {Function}
- * @api public
- */
-
-co.wrap = function (fn) {
-  createPromise.__generatorFunction__ = fn;
-  return createPromise;
-  function createPromise() {
-    return co.call(this, fn.apply(this, arguments));
-  }
-};
-
-/**
- * Execute the generator function or a generator
- * and return a promise.
- *
- * @param {Function} fn
- * @return {Promise}
- * @api public
- */
-
-function co(gen) {
-  var ctx = this;
-  var args = slice.call(arguments, 1)
-
-  // we wrap everything in a promise to avoid promise chaining,
-  // which leads to memory leak errors.
-  // see https://github.com/tj/co/issues/180
-  return new Promise(function(resolve, reject) {
-    if (typeof gen === 'function') gen = gen.apply(ctx, args);
-    if (!gen || typeof gen.next !== 'function') return resolve(gen);
-
-    onFulfilled();
-
+  // lib/transport.js
+  var Transport = class {
     /**
-     * @param {Mixed} res
-     * @return {Promise}
-     * @api private
+     * @param {dav.Credentials} credentials user authorization.
      */
-
-    function onFulfilled(res) {
-      var ret;
-      try {
-        ret = gen.next(res);
-      } catch (e) {
-        return reject(e);
-      }
-      next(ret);
+    constructor(credentials) {
+      this.credentials = credentials || null;
     }
-
     /**
-     * @param {Error} err
-     * @return {Promise}
-     * @api private
-     */
-
-    function onRejected(err) {
-      var ret;
-      try {
-        ret = gen.throw(err);
-      } catch (e) {
-        return reject(e);
-      }
-      next(ret);
-    }
-
-    /**
-     * Get the next value in the generator,
-     * return a promise.
+     * @param {dav.Request} request object with request info.
+     * @return {Promise} a promise that will be resolved with an xhr request after
+     *     its readyState is 4 or the result of applying an optional request
+     *     `transformResponse` function to the xhr object after its readyState is 4.
      *
-     * @param {Object} ret
-     * @return {Promise}
-     * @api private
+     * Options:
+     *
+     *   (Object) sandbox - optional request sandbox.
      */
-
-    function next(ret) {
-      if (ret.done) return resolve(ret.value);
-      var value = toPromise.call(ctx, ret.value);
-      if (value && isPromise(value)) return value.then(onFulfilled, onRejected);
-      return onRejected(new TypeError('You may only yield a function, promise, generator, array, or object, '
-        + 'but the following object was passed: "' + String(ret.value) + '"'));
+    send() {
     }
-  });
-}
-
-/**
- * Convert a `yield`ed value into a promise.
- *
- * @param {Mixed} obj
- * @return {Promise}
- * @api private
- */
-
-function toPromise(obj) {
-  if (!obj) return obj;
-  if (isPromise(obj)) return obj;
-  if (isGeneratorFunction(obj) || isGenerator(obj)) return co.call(this, obj);
-  if ('function' == typeof obj) return thunkToPromise.call(this, obj);
-  if (Array.isArray(obj)) return arrayToPromise.call(this, obj);
-  if (isObject(obj)) return objectToPromise.call(this, obj);
-  return obj;
-}
-
-/**
- * Convert a thunk to a promise.
- *
- * @param {Function}
- * @return {Promise}
- * @api private
- */
-
-function thunkToPromise(fn) {
-  var ctx = this;
-  return new Promise(function (resolve, reject) {
-    fn.call(ctx, function (err, res) {
-      if (err) return reject(err);
-      if (arguments.length > 2) res = slice.call(arguments, 1);
-      resolve(res);
-    });
-  });
-}
-
-/**
- * Convert an array of "yieldables" to a promise.
- * Uses `Promise.all()` internally.
- *
- * @param {Array} obj
- * @return {Promise}
- * @api private
- */
-
-function arrayToPromise(obj) {
-  return Promise.all(obj.map(toPromise, this));
-}
-
-/**
- * Convert an object of "yieldables" to a promise.
- * Uses `Promise.all()` internally.
- *
- * @param {Object} obj
- * @return {Promise}
- * @api private
- */
-
-function objectToPromise(obj){
-  var results = new obj.constructor();
-  var keys = Object.keys(obj);
-  var promises = [];
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i];
-    var promise = toPromise.call(this, obj[key]);
-    if (promise && isPromise(promise)) defer(promise, key);
-    else results[key] = obj[key];
-  }
-  return Promise.all(promises).then(function () {
-    return results;
-  });
-
-  function defer(promise, key) {
-    // predefine the key in the result
-    results[key] = undefined;
-    promises.push(promise.then(function (res) {
-      results[key] = res;
-    }));
-  }
-}
-
-/**
- * Check if `obj` is a promise.
- *
- * @param {Object} obj
- * @return {Boolean}
- * @api private
- */
-
-function isPromise(obj) {
-  return 'function' == typeof obj.then;
-}
-
-/**
- * Check if `obj` is a generator.
- *
- * @param {Mixed} obj
- * @return {Boolean}
- * @api private
- */
-
-function isGenerator(obj) {
-  return 'function' == typeof obj.next && 'function' == typeof obj.throw;
-}
-
-/**
- * Check if `obj` is a generator function.
- *
- * @param {Mixed} obj
- * @return {Boolean}
- * @api private
- */
-function isGeneratorFunction(obj) {
-  var constructor = obj.constructor;
-  if (!constructor) return false;
-  if ('GeneratorFunction' === constructor.name || 'GeneratorFunction' === constructor.displayName) return true;
-  return isGenerator(constructor.prototype);
-}
-
-/**
- * Check for plain object.
- *
- * @param {Mixed} val
- * @return {Boolean}
- * @api private
- */
-
-function isObject(val) {
-  return Object == val.constructor;
-}
-
-},{}],27:[function(require,module,exports){
-(function (global){
-/*! https://mths.be/punycode v1.4.1 by @mathias */
-;(function(root) {
-
-	/** Detect free variables */
-	var freeExports = typeof exports == 'object' && exports &&
-		!exports.nodeType && exports;
-	var freeModule = typeof module == 'object' && module &&
-		!module.nodeType && module;
-	var freeGlobal = typeof global == 'object' && global;
-	if (
-		freeGlobal.global === freeGlobal ||
-		freeGlobal.window === freeGlobal ||
-		freeGlobal.self === freeGlobal
-	) {
-		root = freeGlobal;
-	}
-
-	/**
-	 * The `punycode` object.
-	 * @name punycode
-	 * @type Object
-	 */
-	var punycode,
-
-	/** Highest positive signed 32-bit float value */
-	maxInt = 2147483647, // aka. 0x7FFFFFFF or 2^31-1
-
-	/** Bootstring parameters */
-	base = 36,
-	tMin = 1,
-	tMax = 26,
-	skew = 38,
-	damp = 700,
-	initialBias = 72,
-	initialN = 128, // 0x80
-	delimiter = '-', // '\x2D'
-
-	/** Regular expressions */
-	regexPunycode = /^xn--/,
-	regexNonASCII = /[^\x20-\x7E]/, // unprintable ASCII chars + non-ASCII chars
-	regexSeparators = /[\x2E\u3002\uFF0E\uFF61]/g, // RFC 3490 separators
-
-	/** Error messages */
-	errors = {
-		'overflow': 'Overflow: input needs wider integers to process',
-		'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
-		'invalid-input': 'Invalid input'
-	},
-
-	/** Convenience shortcuts */
-	baseMinusTMin = base - tMin,
-	floor = Math.floor,
-	stringFromCharCode = String.fromCharCode,
-
-	/** Temporary variable */
-	key;
-
-	/*--------------------------------------------------------------------------*/
-
-	/**
-	 * A generic error utility function.
-	 * @private
-	 * @param {String} type The error type.
-	 * @returns {Error} Throws a `RangeError` with the applicable error message.
-	 */
-	function error(type) {
-		throw new RangeError(errors[type]);
-	}
-
-	/**
-	 * A generic `Array#map` utility function.
-	 * @private
-	 * @param {Array} array The array to iterate over.
-	 * @param {Function} callback The function that gets called for every array
-	 * item.
-	 * @returns {Array} A new array of values returned by the callback function.
-	 */
-	function map(array, fn) {
-		var length = array.length;
-		var result = [];
-		while (length--) {
-			result[length] = fn(array[length]);
-		}
-		return result;
-	}
-
-	/**
-	 * A simple `Array#map`-like wrapper to work with domain name strings or email
-	 * addresses.
-	 * @private
-	 * @param {String} domain The domain name or email address.
-	 * @param {Function} callback The function that gets called for every
-	 * character.
-	 * @returns {Array} A new string of characters returned by the callback
-	 * function.
-	 */
-	function mapDomain(string, fn) {
-		var parts = string.split('@');
-		var result = '';
-		if (parts.length > 1) {
-			// In email addresses, only the domain name should be punycoded. Leave
-			// the local part (i.e. everything up to `@`) intact.
-			result = parts[0] + '@';
-			string = parts[1];
-		}
-		// Avoid `split(regex)` for IE8 compatibility. See #17.
-		string = string.replace(regexSeparators, '\x2E');
-		var labels = string.split('.');
-		var encoded = map(labels, fn).join('.');
-		return result + encoded;
-	}
-
-	/**
-	 * Creates an array containing the numeric code points of each Unicode
-	 * character in the string. While JavaScript uses UCS-2 internally,
-	 * this function will convert a pair of surrogate halves (each of which
-	 * UCS-2 exposes as separate characters) into a single code point,
-	 * matching UTF-16.
-	 * @see `punycode.ucs2.encode`
-	 * @see <https://mathiasbynens.be/notes/javascript-encoding>
-	 * @memberOf punycode.ucs2
-	 * @name decode
-	 * @param {String} string The Unicode input string (UCS-2).
-	 * @returns {Array} The new array of code points.
-	 */
-	function ucs2decode(string) {
-		var output = [],
-		    counter = 0,
-		    length = string.length,
-		    value,
-		    extra;
-		while (counter < length) {
-			value = string.charCodeAt(counter++);
-			if (value >= 0xD800 && value <= 0xDBFF && counter < length) {
-				// high surrogate, and there is a next character
-				extra = string.charCodeAt(counter++);
-				if ((extra & 0xFC00) == 0xDC00) { // low surrogate
-					output.push(((value & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000);
-				} else {
-					// unmatched surrogate; only append this code unit, in case the next
-					// code unit is the high surrogate of a surrogate pair
-					output.push(value);
-					counter--;
-				}
-			} else {
-				output.push(value);
-			}
-		}
-		return output;
-	}
-
-	/**
-	 * Creates a string based on an array of numeric code points.
-	 * @see `punycode.ucs2.decode`
-	 * @memberOf punycode.ucs2
-	 * @name encode
-	 * @param {Array} codePoints The array of numeric code points.
-	 * @returns {String} The new Unicode string (UCS-2).
-	 */
-	function ucs2encode(array) {
-		return map(array, function(value) {
-			var output = '';
-			if (value > 0xFFFF) {
-				value -= 0x10000;
-				output += stringFromCharCode(value >>> 10 & 0x3FF | 0xD800);
-				value = 0xDC00 | value & 0x3FF;
-			}
-			output += stringFromCharCode(value);
-			return output;
-		}).join('');
-	}
-
-	/**
-	 * Converts a basic code point into a digit/integer.
-	 * @see `digitToBasic()`
-	 * @private
-	 * @param {Number} codePoint The basic numeric code point value.
-	 * @returns {Number} The numeric value of a basic code point (for use in
-	 * representing integers) in the range `0` to `base - 1`, or `base` if
-	 * the code point does not represent a value.
-	 */
-	function basicToDigit(codePoint) {
-		if (codePoint - 48 < 10) {
-			return codePoint - 22;
-		}
-		if (codePoint - 65 < 26) {
-			return codePoint - 65;
-		}
-		if (codePoint - 97 < 26) {
-			return codePoint - 97;
-		}
-		return base;
-	}
-
-	/**
-	 * Converts a digit/integer into a basic code point.
-	 * @see `basicToDigit()`
-	 * @private
-	 * @param {Number} digit The numeric value of a basic code point.
-	 * @returns {Number} The basic code point whose value (when used for
-	 * representing integers) is `digit`, which needs to be in the range
-	 * `0` to `base - 1`. If `flag` is non-zero, the uppercase form is
-	 * used; else, the lowercase form is used. The behavior is undefined
-	 * if `flag` is non-zero and `digit` has no uppercase form.
-	 */
-	function digitToBasic(digit, flag) {
-		//  0..25 map to ASCII a..z or A..Z
-		// 26..35 map to ASCII 0..9
-		return digit + 22 + 75 * (digit < 26) - ((flag != 0) << 5);
-	}
-
-	/**
-	 * Bias adaptation function as per section 3.4 of RFC 3492.
-	 * https://tools.ietf.org/html/rfc3492#section-3.4
-	 * @private
-	 */
-	function adapt(delta, numPoints, firstTime) {
-		var k = 0;
-		delta = firstTime ? floor(delta / damp) : delta >> 1;
-		delta += floor(delta / numPoints);
-		for (/* no initialization */; delta > baseMinusTMin * tMax >> 1; k += base) {
-			delta = floor(delta / baseMinusTMin);
-		}
-		return floor(k + (baseMinusTMin + 1) * delta / (delta + skew));
-	}
-
-	/**
-	 * Converts a Punycode string of ASCII-only symbols to a string of Unicode
-	 * symbols.
-	 * @memberOf punycode
-	 * @param {String} input The Punycode string of ASCII-only symbols.
-	 * @returns {String} The resulting string of Unicode symbols.
-	 */
-	function decode(input) {
-		// Don't use UCS-2
-		var output = [],
-		    inputLength = input.length,
-		    out,
-		    i = 0,
-		    n = initialN,
-		    bias = initialBias,
-		    basic,
-		    j,
-		    index,
-		    oldi,
-		    w,
-		    k,
-		    digit,
-		    t,
-		    /** Cached calculation results */
-		    baseMinusT;
-
-		// Handle the basic code points: let `basic` be the number of input code
-		// points before the last delimiter, or `0` if there is none, then copy
-		// the first basic code points to the output.
-
-		basic = input.lastIndexOf(delimiter);
-		if (basic < 0) {
-			basic = 0;
-		}
-
-		for (j = 0; j < basic; ++j) {
-			// if it's not a basic code point
-			if (input.charCodeAt(j) >= 0x80) {
-				error('not-basic');
-			}
-			output.push(input.charCodeAt(j));
-		}
-
-		// Main decoding loop: start just after the last delimiter if any basic code
-		// points were copied; start at the beginning otherwise.
-
-		for (index = basic > 0 ? basic + 1 : 0; index < inputLength; /* no final expression */) {
-
-			// `index` is the index of the next character to be consumed.
-			// Decode a generalized variable-length integer into `delta`,
-			// which gets added to `i`. The overflow checking is easier
-			// if we increase `i` as we go, then subtract off its starting
-			// value at the end to obtain `delta`.
-			for (oldi = i, w = 1, k = base; /* no condition */; k += base) {
-
-				if (index >= inputLength) {
-					error('invalid-input');
-				}
-
-				digit = basicToDigit(input.charCodeAt(index++));
-
-				if (digit >= base || digit > floor((maxInt - i) / w)) {
-					error('overflow');
-				}
-
-				i += digit * w;
-				t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
-
-				if (digit < t) {
-					break;
-				}
-
-				baseMinusT = base - t;
-				if (w > floor(maxInt / baseMinusT)) {
-					error('overflow');
-				}
-
-				w *= baseMinusT;
-
-			}
-
-			out = output.length + 1;
-			bias = adapt(i - oldi, out, oldi == 0);
-
-			// `i` was supposed to wrap around from `out` to `0`,
-			// incrementing `n` each time, so we'll fix that now:
-			if (floor(i / out) > maxInt - n) {
-				error('overflow');
-			}
-
-			n += floor(i / out);
-			i %= out;
-
-			// Insert `n` at position `i` of the output
-			output.splice(i++, 0, n);
-
-		}
-
-		return ucs2encode(output);
-	}
-
-	/**
-	 * Converts a string of Unicode symbols (e.g. a domain name label) to a
-	 * Punycode string of ASCII-only symbols.
-	 * @memberOf punycode
-	 * @param {String} input The string of Unicode symbols.
-	 * @returns {String} The resulting Punycode string of ASCII-only symbols.
-	 */
-	function encode(input) {
-		var n,
-		    delta,
-		    handledCPCount,
-		    basicLength,
-		    bias,
-		    j,
-		    m,
-		    q,
-		    k,
-		    t,
-		    currentValue,
-		    output = [],
-		    /** `inputLength` will hold the number of code points in `input`. */
-		    inputLength,
-		    /** Cached calculation results */
-		    handledCPCountPlusOne,
-		    baseMinusT,
-		    qMinusT;
-
-		// Convert the input in UCS-2 to Unicode
-		input = ucs2decode(input);
-
-		// Cache the length
-		inputLength = input.length;
-
-		// Initialize the state
-		n = initialN;
-		delta = 0;
-		bias = initialBias;
-
-		// Handle the basic code points
-		for (j = 0; j < inputLength; ++j) {
-			currentValue = input[j];
-			if (currentValue < 0x80) {
-				output.push(stringFromCharCode(currentValue));
-			}
-		}
-
-		handledCPCount = basicLength = output.length;
-
-		// `handledCPCount` is the number of code points that have been handled;
-		// `basicLength` is the number of basic code points.
-
-		// Finish the basic string - if it is not empty - with a delimiter
-		if (basicLength) {
-			output.push(delimiter);
-		}
-
-		// Main encoding loop:
-		while (handledCPCount < inputLength) {
-
-			// All non-basic code points < n have been handled already. Find the next
-			// larger one:
-			for (m = maxInt, j = 0; j < inputLength; ++j) {
-				currentValue = input[j];
-				if (currentValue >= n && currentValue < m) {
-					m = currentValue;
-				}
-			}
-
-			// Increase `delta` enough to advance the decoder's <n,i> state to <m,0>,
-			// but guard against overflow
-			handledCPCountPlusOne = handledCPCount + 1;
-			if (m - n > floor((maxInt - delta) / handledCPCountPlusOne)) {
-				error('overflow');
-			}
-
-			delta += (m - n) * handledCPCountPlusOne;
-			n = m;
-
-			for (j = 0; j < inputLength; ++j) {
-				currentValue = input[j];
-
-				if (currentValue < n && ++delta > maxInt) {
-					error('overflow');
-				}
-
-				if (currentValue == n) {
-					// Represent delta as a generalized variable-length integer
-					for (q = delta, k = base; /* no condition */; k += base) {
-						t = k <= bias ? tMin : (k >= bias + tMax ? tMax : k - bias);
-						if (q < t) {
-							break;
-						}
-						qMinusT = q - t;
-						baseMinusT = base - t;
-						output.push(
-							stringFromCharCode(digitToBasic(t + qMinusT % baseMinusT, 0))
-						);
-						q = floor(qMinusT / baseMinusT);
-					}
-
-					output.push(stringFromCharCode(digitToBasic(q, 0)));
-					bias = adapt(delta, handledCPCountPlusOne, handledCPCount == basicLength);
-					delta = 0;
-					++handledCPCount;
-				}
-			}
-
-			++delta;
-			++n;
-
-		}
-		return output.join('');
-	}
-
-	/**
-	 * Converts a Punycode string representing a domain name or an email address
-	 * to Unicode. Only the Punycoded parts of the input will be converted, i.e.
-	 * it doesn't matter if you call it on a string that has already been
-	 * converted to Unicode.
-	 * @memberOf punycode
-	 * @param {String} input The Punycoded domain name or email address to
-	 * convert to Unicode.
-	 * @returns {String} The Unicode representation of the given Punycode
-	 * string.
-	 */
-	function toUnicode(input) {
-		return mapDomain(input, function(string) {
-			return regexPunycode.test(string)
-				? decode(string.slice(4).toLowerCase())
-				: string;
-		});
-	}
-
-	/**
-	 * Converts a Unicode string representing a domain name or an email address to
-	 * Punycode. Only the non-ASCII parts of the domain name will be converted,
-	 * i.e. it doesn't matter if you call it with a domain that's already in
-	 * ASCII.
-	 * @memberOf punycode
-	 * @param {String} input The domain name or email address to convert, as a
-	 * Unicode string.
-	 * @returns {String} The Punycode representation of the given domain name or
-	 * email address.
-	 */
-	function toASCII(input) {
-		return mapDomain(input, function(string) {
-			return regexNonASCII.test(string)
-				? 'xn--' + encode(string)
-				: string;
-		});
-	}
-
-	/*--------------------------------------------------------------------------*/
-
-	/** Define the public API */
-	punycode = {
-		/**
-		 * A string representing the current Punycode.js version number.
-		 * @memberOf punycode
-		 * @type String
-		 */
-		'version': '1.4.1',
-		/**
-		 * An object of methods to convert from JavaScript's internal character
-		 * representation (UCS-2) to Unicode code points, and back.
-		 * @see <https://mathiasbynens.be/notes/javascript-encoding>
-		 * @memberOf punycode
-		 * @type Object
-		 */
-		'ucs2': {
-			'decode': ucs2decode,
-			'encode': ucs2encode
-		},
-		'decode': decode,
-		'encode': encode,
-		'toASCII': toASCII,
-		'toUnicode': toUnicode
-	};
-
-	/** Expose `punycode` */
-	// Some AMD build optimizers, like r.js, check for specific condition patterns
-	// like the following:
-	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
-		define.amd
-	) {
-		define('punycode', function() {
-			return punycode;
-		});
-	} else if (freeExports && freeModule) {
-		if (module.exports == freeExports) {
-			// in Node.js, io.js, or RingoJS v0.8.0+
-			freeModule.exports = punycode;
-		} else {
-			// in Narwhal or RingoJS v0.7.0-
-			for (key in punycode) {
-				punycode.hasOwnProperty(key) && (freeExports[key] = punycode[key]);
-			}
-		}
-	} else {
-		// in Rhino or a web browser
-		root.punycode = punycode;
-	}
-
-}(this));
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],28:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-'use strict';
-
-// If obj.hasOwnProperty has been overridden, then calling
-// obj.hasOwnProperty(prop) will break.
-// See: https://github.com/joyent/node/issues/1707
-function hasOwnProperty(obj, prop) {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
-}
-
-module.exports = function(qs, sep, eq, options) {
-  sep = sep || '&';
-  eq = eq || '=';
-  var obj = {};
-
-  if (typeof qs !== 'string' || qs.length === 0) {
-    return obj;
-  }
-
-  var regexp = /\+/g;
-  qs = qs.split(sep);
-
-  var maxKeys = 1000;
-  if (options && typeof options.maxKeys === 'number') {
-    maxKeys = options.maxKeys;
-  }
-
-  var len = qs.length;
-  // maxKeys <= 0 means that we should not limit keys count
-  if (maxKeys > 0 && len > maxKeys) {
-    len = maxKeys;
-  }
-
-  for (var i = 0; i < len; ++i) {
-    var x = qs[i].replace(regexp, '%20'),
-        idx = x.indexOf(eq),
-        kstr, vstr, k, v;
-
-    if (idx >= 0) {
-      kstr = x.substr(0, idx);
-      vstr = x.substr(idx + 1);
-    } else {
-      kstr = x;
-      vstr = '';
+  };
+  var Basic = class extends Transport {
+    /**
+     * @param {dav.Credentials} credentials user authorization.
+     */
+    constructor(credentials) {
+      super(credentials);
     }
-
-    k = decodeURIComponent(kstr);
-    v = decodeURIComponent(vstr);
-
-    if (!hasOwnProperty(obj, k)) {
-      obj[k] = v;
-    } else if (isArray(obj[k])) {
-      obj[k].push(v);
-    } else {
-      obj[k] = [obj[k], v];
-    }
-  }
-
-  return obj;
-};
-
-var isArray = Array.isArray || function (xs) {
-  return Object.prototype.toString.call(xs) === '[object Array]';
-};
-
-},{}],29:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-'use strict';
-
-var stringifyPrimitive = function(v) {
-  switch (typeof v) {
-    case 'string':
-      return v;
-
-    case 'boolean':
-      return v ? 'true' : 'false';
-
-    case 'number':
-      return isFinite(v) ? v : '';
-
-    default:
-      return '';
-  }
-};
-
-module.exports = function(obj, sep, eq, name) {
-  sep = sep || '&';
-  eq = eq || '=';
-  if (obj === null) {
-    obj = undefined;
-  }
-
-  if (typeof obj === 'object') {
-    return map(objectKeys(obj), function(k) {
-      var ks = encodeURIComponent(stringifyPrimitive(k)) + eq;
-      if (isArray(obj[k])) {
-        return map(obj[k], function(v) {
-          return ks + encodeURIComponent(stringifyPrimitive(v));
-        }).join(sep);
-      } else {
-        return ks + encodeURIComponent(stringifyPrimitive(obj[k]));
-      }
-    }).join(sep);
-
-  }
-
-  if (!name) return '';
-  return encodeURIComponent(stringifyPrimitive(name)) + eq +
-         encodeURIComponent(stringifyPrimitive(obj));
-};
-
-var isArray = Array.isArray || function (xs) {
-  return Object.prototype.toString.call(xs) === '[object Array]';
-};
-
-function map (xs, f) {
-  if (xs.map) return xs.map(f);
-  var res = [];
-  for (var i = 0; i < xs.length; i++) {
-    res.push(f(xs[i], i));
-  }
-  return res;
-}
-
-var objectKeys = Object.keys || function (obj) {
-  var res = [];
-  for (var key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) res.push(key);
-  }
-  return res;
-};
-
-},{}],30:[function(require,module,exports){
-'use strict';
-
-exports.decode = exports.parse = require('./decode');
-exports.encode = exports.stringify = require('./encode');
-
-},{"./decode":28,"./encode":29}],31:[function(require,module,exports){
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-var punycode = require('punycode');
-
-exports.parse = urlParse;
-exports.resolve = urlResolve;
-exports.resolveObject = urlResolveObject;
-exports.format = urlFormat;
-
-exports.Url = Url;
-
-function Url() {
-  this.protocol = null;
-  this.slashes = null;
-  this.auth = null;
-  this.host = null;
-  this.port = null;
-  this.hostname = null;
-  this.hash = null;
-  this.search = null;
-  this.query = null;
-  this.pathname = null;
-  this.path = null;
-  this.href = null;
-}
-
-// Reference: RFC 3986, RFC 1808, RFC 2396
-
-// define these here so at least they only have to be
-// compiled once on the first module load.
-var protocolPattern = /^([a-z0-9.+-]+:)/i,
-    portPattern = /:[0-9]*$/,
-
-    // RFC 2396: characters reserved for delimiting URLs.
-    // We actually just auto-escape these.
-    delims = ['<', '>', '"', '`', ' ', '\r', '\n', '\t'],
-
-    // RFC 2396: characters not allowed for various reasons.
-    unwise = ['{', '}', '|', '\\', '^', '`'].concat(delims),
-
-    // Allowed by RFCs, but cause of XSS attacks.  Always escape these.
-    autoEscape = ['\''].concat(unwise),
-    // Characters that are never ever allowed in a hostname.
-    // Note that any invalid chars are also handled, but these
-    // are the ones that are *expected* to be seen, so we fast-path
-    // them.
-    nonHostChars = ['%', '/', '?', ';', '#'].concat(autoEscape),
-    hostEndingChars = ['/', '?', '#'],
-    hostnameMaxLen = 255,
-    hostnamePartPattern = /^[a-z0-9A-Z_-]{0,63}$/,
-    hostnamePartStart = /^([a-z0-9A-Z_-]{0,63})(.*)$/,
-    // protocols that can allow "unsafe" and "unwise" chars.
-    unsafeProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that never have a hostname.
-    hostlessProtocol = {
-      'javascript': true,
-      'javascript:': true
-    },
-    // protocols that always contain a // bit.
-    slashedProtocol = {
-      'http': true,
-      'https': true,
-      'ftp': true,
-      'gopher': true,
-      'file': true,
-      'http:': true,
-      'https:': true,
-      'ftp:': true,
-      'gopher:': true,
-      'file:': true
-    },
-    querystring = require('querystring');
-
-function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (url && isObject(url) && url instanceof Url) return url;
-
-  var u = new Url;
-  u.parse(url, parseQueryString, slashesDenoteHost);
-  return u;
-}
-
-Url.prototype.parse = function(url, parseQueryString, slashesDenoteHost) {
-  if (!isString(url)) {
-    throw new TypeError("Parameter 'url' must be a string, not " + typeof url);
-  }
-
-  var rest = url;
-
-  // trim before proceeding.
-  // This is to support parse stuff like "  http://foo.com  \n"
-  rest = rest.trim();
-
-  var proto = protocolPattern.exec(rest);
-  if (proto) {
-    proto = proto[0];
-    var lowerProto = proto.toLowerCase();
-    this.protocol = lowerProto;
-    rest = rest.substr(proto.length);
-  }
-
-  // figure out if it's got a host
-  // user@server is *always* interpreted as a hostname, and url
-  // resolution will treat //foo/bar as host=foo,path=bar because that's
-  // how the browser resolves relative URLs.
-  if (slashesDenoteHost || proto || rest.match(/^\/\/[^@\/]+@[^@\/]+/)) {
-    var slashes = rest.substr(0, 2) === '//';
-    if (slashes && !(proto && hostlessProtocol[proto])) {
-      rest = rest.substr(2);
-      this.slashes = true;
-    }
-  }
-
-  if (!hostlessProtocol[proto] &&
-      (slashes || (proto && !slashedProtocol[proto]))) {
-
-    // there's a hostname.
-    // the first instance of /, ?, ;, or # ends the host.
-    //
-    // If there is an @ in the hostname, then non-host chars *are* allowed
-    // to the left of the last @ sign, unless some host-ending character
-    // comes *before* the @-sign.
-    // URLs are obnoxious.
-    //
-    // ex:
-    // http://a@b@c/ => user:a@b host:c
-    // http://a@b?@c => user:a host:c path:/?@c
-
-    // v0.12 TODO(isaacs): This is not quite how Chrome does things.
-    // Review our test case against browsers more comprehensively.
-
-    // find the first instance of any hostEndingChars
-    var hostEnd = -1;
-    for (var i = 0; i < hostEndingChars.length; i++) {
-      var hec = rest.indexOf(hostEndingChars[i]);
-      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
-        hostEnd = hec;
-    }
-
-    // at this point, either we have an explicit point where the
-    // auth portion cannot go past, or the last @ char is the decider.
-    var auth, atSign;
-    if (hostEnd === -1) {
-      // atSign can be anywhere.
-      atSign = rest.lastIndexOf('@');
-    } else {
-      // atSign must be in auth portion.
-      // http://a@b/c@d => host:b auth:a path:/c@d
-      atSign = rest.lastIndexOf('@', hostEnd);
-    }
-
-    // Now we have a portion which is definitely the auth.
-    // Pull that off.
-    if (atSign !== -1) {
-      auth = rest.slice(0, atSign);
-      rest = rest.slice(atSign + 1);
-      this.auth = decodeURIComponent(auth);
-    }
-
-    // the host is the remaining to the left of the first non-host char
-    hostEnd = -1;
-    for (var i = 0; i < nonHostChars.length; i++) {
-      var hec = rest.indexOf(nonHostChars[i]);
-      if (hec !== -1 && (hostEnd === -1 || hec < hostEnd))
-        hostEnd = hec;
-    }
-    // if we still have not hit it, then the entire thing is a host.
-    if (hostEnd === -1)
-      hostEnd = rest.length;
-
-    this.host = rest.slice(0, hostEnd);
-    rest = rest.slice(hostEnd);
-
-    // pull out port.
-    this.parseHost();
-
-    // we've indicated that there is a hostname,
-    // so even if it's empty, it has to be present.
-    this.hostname = this.hostname || '';
-
-    // if hostname begins with [ and ends with ]
-    // assume that it's an IPv6 address.
-    var ipv6Hostname = this.hostname[0] === '[' &&
-        this.hostname[this.hostname.length - 1] === ']';
-
-    // validate a little.
-    if (!ipv6Hostname) {
-      var hostparts = this.hostname.split(/\./);
-      for (var i = 0, l = hostparts.length; i < l; i++) {
-        var part = hostparts[i];
-        if (!part) continue;
-        if (!part.match(hostnamePartPattern)) {
-          var newpart = '';
-          for (var j = 0, k = part.length; j < k; j++) {
-            if (part.charCodeAt(j) > 127) {
-              // we replace non-ASCII char with a temporary placeholder
-              // we need this to make sure size of hostname is not
-              // broken by replacing non-ASCII by nothing
-              newpart += 'x';
-            } else {
-              newpart += part[j];
-            }
-          }
-          // we test again with ASCII char only
-          if (!newpart.match(hostnamePartPattern)) {
-            var validParts = hostparts.slice(0, i);
-            var notHost = hostparts.slice(i + 1);
-            var bit = part.match(hostnamePartStart);
-            if (bit) {
-              validParts.push(bit[1]);
-              notHost.unshift(bit[2]);
-            }
-            if (notHost.length) {
-              rest = '/' + notHost.join('.') + rest;
-            }
-            this.hostname = validParts.join('.');
-            break;
-          }
+    send(request, url4, options) {
+      return (0, import_co.default)(function* () {
+        let sandbox = options && options.sandbox;
+        let transformRequest = request.transformRequest;
+        let transformResponse = request.transformResponse;
+        let onerror = request.onerror;
+        let xhr = new XMLHttpRequest();
+        if (sandbox) sandbox.add(xhr);
+        xhr.open(
+          request.method,
+          url4,
+          true,
+          this.credentials.username,
+          this.credentials.password
+        );
+        if (transformRequest) transformRequest(xhr);
+        let result;
+        try {
+          xhr.setRequestHeader("requesttoken", oc_requesttoken);
+          yield xhr.send(request.requestData);
+          result = transformResponse ? transformResponse(xhr) : xhr;
+        } catch (error) {
+          if (onerror) onerror(error);
+          throw error;
         }
-      }
+        return result;
+      }.bind(this));
     }
-
-    if (this.hostname.length > hostnameMaxLen) {
-      this.hostname = '';
-    } else {
-      // hostnames are always lower case.
-      this.hostname = this.hostname.toLowerCase();
+  };
+  var OAuth2 = class extends Transport {
+    constructor(credentials) {
+      super(credentials);
     }
-
-    if (!ipv6Hostname) {
-      // IDNA Support: Returns a puny coded representation of "domain".
-      // It only converts the part of the domain name that
-      // has non ASCII characters. I.e. it dosent matter if
-      // you call it with a domain that already is in ASCII.
-      var domainArray = this.hostname.split('.');
-      var newOut = [];
-      for (var i = 0; i < domainArray.length; ++i) {
-        var s = domainArray[i];
-        newOut.push(s.match(/[^A-Za-z0-9_-]/) ?
-            'xn--' + punycode.encode(s) : s);
-      }
-      this.hostname = newOut.join('.');
+    send(request, url4, options = {}) {
+      return (0, import_co.default)(function* () {
+        let sandbox = options.sandbox;
+        let transformRequest = request.transformRequest;
+        let transformResponse = request.transformResponse;
+        let onerror = request.onerror;
+        if (!("retry" in options)) options.retry = true;
+        let result, xhr;
+        try {
+          let token = yield access(this.credentials, options);
+          xhr = new XMLHttpRequest();
+          if (sandbox) sandbox.add(xhr);
+          xhr.open(
+            request.method,
+            url4,
+            true
+            /* async */
+          );
+          xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+          if (transformRequest) transformRequest(xhr);
+          xhr.setRequestHeader("requesttoken", oc_requesttoken);
+          yield xhr.send(request.requestData);
+          result = transformResponse ? transformResponse(xhr) : xhr;
+        } catch (error) {
+          if (options.retry && xhr.status === 401) {
+            this.credentials.expiration = 0;
+            options.retry = false;
+            return this.send(request, url4, options);
+          }
+          if (onerror) onerror(error);
+          throw error;
+        }
+        return result;
+      }.bind(this));
     }
-
-    var p = this.port ? ':' + this.port : '';
-    var h = this.hostname || '';
-    this.host = h + p;
-    this.href += this.host;
-
-    // strip [ and ] from the hostname
-    // the host field still retains them, though
-    if (ipv6Hostname) {
-      this.hostname = this.hostname.substr(1, this.hostname.length - 2);
-      if (rest[0] !== '/') {
-        rest = '/' + rest;
-      }
+  };
+  function access(credentials, options) {
+    if (!credentials.accessToken) {
+      return getAccessToken(credentials, options);
     }
-  }
-
-  // now rest is set to the post-host stuff.
-  // chop off any delim chars.
-  if (!unsafeProtocol[lowerProto]) {
-
-    // First, make 100% sure that any "autoEscape" chars get
-    // escaped, even if encodeURIComponent doesn't think they
-    // need to be.
-    for (var i = 0, l = autoEscape.length; i < l; i++) {
-      var ae = autoEscape[i];
-      var esc = encodeURIComponent(ae);
-      if (esc === ae) {
-        esc = escape(ae);
-      }
-      rest = rest.split(ae).join(esc);
+    if (credentials.refreshToken && isExpired(credentials)) {
+      return refreshAccessToken(credentials, options);
     }
+    return Promise.resolve(credentials.accessToken);
   }
-
-
-  // chop off from the tail first.
-  var hash = rest.indexOf('#');
-  if (hash !== -1) {
-    // got a fragment string.
-    this.hash = rest.substr(hash);
-    rest = rest.slice(0, hash);
+  function isExpired(credentials) {
+    return typeof credentials.expiration === "number" && Date.now() > credentials.expiration;
   }
-  var qm = rest.indexOf('?');
-  if (qm !== -1) {
-    this.search = rest.substr(qm);
-    this.query = rest.substr(qm + 1);
-    if (parseQueryString) {
-      this.query = querystring.parse(this.query);
-    }
-    rest = rest.slice(0, qm);
-  } else if (parseQueryString) {
-    // no query string, but parseQueryString still requested
-    this.search = '';
-    this.query = {};
-  }
-  if (rest) this.pathname = rest;
-  if (slashedProtocol[lowerProto] &&
-      this.hostname && !this.pathname) {
-    this.pathname = '/';
-  }
-
-  //to support http.request
-  if (this.pathname || this.search) {
-    var p = this.pathname || '';
-    var s = this.search || '';
-    this.path = p + s;
-  }
-
-  // finally, reconstruct the href based on what has been validated.
-  this.href = this.format();
-  return this;
-};
-
-// format a parsed object into a url string
-function urlFormat(obj) {
-  // ensure it's an object, and not a string url.
-  // If it's an obj, this is a no-op.
-  // this way, you can call url_format() on strings
-  // to clean up potentially wonky urls.
-  if (isString(obj)) obj = urlParse(obj);
-  if (!(obj instanceof Url)) return Url.prototype.format.call(obj);
-  return obj.format();
-}
-
-Url.prototype.format = function() {
-  var auth = this.auth || '';
-  if (auth) {
-    auth = encodeURIComponent(auth);
-    auth = auth.replace(/%3A/i, ':');
-    auth += '@';
-  }
-
-  var protocol = this.protocol || '',
-      pathname = this.pathname || '',
-      hash = this.hash || '',
-      host = false,
-      query = '';
-
-  if (this.host) {
-    host = auth + this.host;
-  } else if (this.hostname) {
-    host = auth + (this.hostname.indexOf(':') === -1 ?
-        this.hostname :
-        '[' + this.hostname + ']');
-    if (this.port) {
-      host += ':' + this.port;
-    }
-  }
-
-  if (this.query &&
-      isObject(this.query) &&
-      Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
-  }
-
-  var search = this.search || (query && ('?' + query)) || '';
-
-  if (protocol && protocol.substr(-1) !== ':') protocol += ':';
-
-  // only the slashedProtocols get the //.  Not mailto:, xmpp:, etc.
-  // unless they had them to begin with.
-  if (this.slashes ||
-      (!protocol || slashedProtocol[protocol]) && host !== false) {
-    host = '//' + (host || '');
-    if (pathname && pathname.charAt(0) !== '/') pathname = '/' + pathname;
-  } else if (!host) {
-    host = '';
-  }
-
-  if (hash && hash.charAt(0) !== '#') hash = '#' + hash;
-  if (search && search.charAt(0) !== '?') search = '?' + search;
-
-  pathname = pathname.replace(/[?#]/g, function(match) {
-    return encodeURIComponent(match);
-  });
-  search = search.replace('#', '%23');
-
-  return protocol + host + pathname + search + hash;
-};
-
-function urlResolve(source, relative) {
-  return urlParse(source, false, true).resolve(relative);
-}
-
-Url.prototype.resolve = function(relative) {
-  return this.resolveObject(urlParse(relative, false, true)).format();
-};
-
-function urlResolveObject(source, relative) {
-  if (!source) return relative;
-  return urlParse(source, false, true).resolveObject(relative);
-}
-
-Url.prototype.resolveObject = function(relative) {
-  if (isString(relative)) {
-    var rel = new Url();
-    rel.parse(relative, false, true);
-    relative = rel;
-  }
-
-  var result = new Url();
-  Object.keys(this).forEach(function(k) {
-    result[k] = this[k];
-  }, this);
-
-  // hash is always overridden, no matter what.
-  // even href="" will remove it.
-  result.hash = relative.hash;
-
-  // if the relative url is empty, then there's nothing left to do here.
-  if (relative.href === '') {
-    result.href = result.format();
-    return result;
-  }
-
-  // hrefs like //foo/bar always cut to the protocol.
-  if (relative.slashes && !relative.protocol) {
-    // take everything except the protocol from relative
-    Object.keys(relative).forEach(function(k) {
-      if (k !== 'protocol')
-        result[k] = relative[k];
+  var getAccessToken = import_co.default.wrap(function* (credentials, options) {
+    let sandbox = options.sandbox;
+    let xhr = new XMLHttpRequest();
+    if (sandbox) sandbox.add(xhr);
+    xhr.open(
+      "POST",
+      credentials.tokenUrl,
+      true
+      /* async */
+    );
+    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    let data = import_querystring.default.stringify({
+      code: credentials.authorizationCode,
+      redirect_uri: credentials.redirectUrl,
+      client_id: credentials.clientId,
+      client_secret: credentials.clientSecret,
+      grant_type: "authorization_code"
     });
+    let now = Date.now();
+    yield xhr.send(data);
+    let response = JSON.parse(xhr.responseText);
+    credentials.accessToken = response.access_token;
+    credentials.refreshToken = "refresh_token" in response ? response.refresh_token : null;
+    credentials.expiration = "expires_in" in response ? now + response.expires_in : null;
+    return response.access_token;
+  });
+  var refreshAccessToken = import_co.default.wrap(function* (credentials, options) {
+    let sandbox = options.sandbox;
+    let xhr = new XMLHttpRequest();
+    if (sandbox) sandbox.add(xhr);
+    xhr.open(
+      "POST",
+      credentials.tokenUrl,
+      true
+      /* async */
+    );
+    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    let data = import_querystring.default.stringify({
+      client_id: credentials.clientId,
+      client_secret: credentials.clientSecret,
+      refresh_token: credentials.refreshToken,
+      grant_type: "refresh_token"
+    });
+    let now = Date.now();
+    yield xhr.send(data);
+    let response = JSON.parse(xhr.responseText);
+    credentials.accessToken = response.access_token;
+    credentials.expiration = "expires_in" in response ? now + response.expires_in : null;
+    return response.access_token;
+  });
 
-    //urlParse appends trailing / to urls like http://www.example.com
-    if (slashedProtocol[result.protocol] &&
-        result.hostname && !result.pathname) {
-      result.path = result.pathname = '/';
+  // package.json
+  var version = "1.8.0";
+
+  // lib/index.js
+  var import_accounts = __toESM(require_accounts());
+  init_calendars();
+
+  // lib/client.js
+  var import_url3 = __toESM(require_url());
+  var accounts = __toESM(require_accounts());
+  init_calendars();
+  init_contacts();
+  var Client = class {
+    constructor(xhr, options = {}) {
+      this.xhr = xhr;
+      Object.assign(this, options);
+      this._accounts = accounts;
+      this._calendars = calendars_exports;
+      this._contacts = contacts_exports;
     }
-
-    result.href = result.format();
-    return result;
-  }
-
-  if (relative.protocol && relative.protocol !== result.protocol) {
-    // if it's a known url protocol, then changing
-    // the protocol does weird things
-    // first, if it's not file:, then we MUST have a host,
-    // and if there was a path
-    // to begin with, then we MUST have a path.
-    // if it is file:, then the host is dropped,
-    // because that's known to be hostless.
-    // anything else is assumed to be absolute.
-    if (!slashedProtocol[relative.protocol]) {
-      Object.keys(relative).forEach(function(k) {
-        result[k] = relative[k];
-      });
-      result.href = result.format();
-      return result;
-    }
-
-    result.protocol = relative.protocol;
-    if (!relative.host && !hostlessProtocol[relative.protocol]) {
-      var relPath = (relative.pathname || '').split('/');
-      while (relPath.length && !(relative.host = relPath.shift()));
-      if (!relative.host) relative.host = '';
-      if (!relative.hostname) relative.hostname = '';
-      if (relPath[0] !== '') relPath.unshift('');
-      if (relPath.length < 2) relPath.unshift('');
-      result.pathname = relPath.join('/');
-    } else {
-      result.pathname = relative.pathname;
-    }
-    result.search = relative.search;
-    result.query = relative.query;
-    result.host = relative.host || '';
-    result.auth = relative.auth;
-    result.hostname = relative.hostname || relative.host;
-    result.port = relative.port;
-    // to support http.request
-    if (result.pathname || result.search) {
-      var p = result.pathname || '';
-      var s = result.search || '';
-      result.path = p + s;
-    }
-    result.slashes = result.slashes || relative.slashes;
-    result.href = result.format();
-    return result;
-  }
-
-  var isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/'),
-      isRelAbs = (
-          relative.host ||
-          relative.pathname && relative.pathname.charAt(0) === '/'
-      ),
-      mustEndAbs = (isRelAbs || isSourceAbs ||
-                    (result.host && relative.pathname)),
-      removeAllDots = mustEndAbs,
-      srcPath = result.pathname && result.pathname.split('/') || [],
-      relPath = relative.pathname && relative.pathname.split('/') || [],
-      psychotic = result.protocol && !slashedProtocol[result.protocol];
-
-  // if the url is a non-slashed url, then relative
-  // links like ../.. should be able
-  // to crawl up to the hostname, as well.  This is strange.
-  // result.protocol has already been set by now.
-  // Later on, put the first path part into the host field.
-  if (psychotic) {
-    result.hostname = '';
-    result.port = null;
-    if (result.host) {
-      if (srcPath[0] === '') srcPath[0] = result.host;
-      else srcPath.unshift(result.host);
-    }
-    result.host = '';
-    if (relative.protocol) {
-      relative.hostname = null;
-      relative.port = null;
-      if (relative.host) {
-        if (relPath[0] === '') relPath[0] = relative.host;
-        else relPath.unshift(relative.host);
+    /**
+     * @param {dav.Request} req - dav request.
+     * @param {String} uri - where to send request.
+     * @return {Promise} a promise that will be resolved with an xhr request
+     *     after its readyState is 4 or the result of applying an optional
+     *     request `transformResponse` function to the xhr object after its
+     *     readyState is 4.
+     *
+     * Options:
+     *
+     *   (Object) sandbox - optional request sandbox.
+     */
+    send(req, uri, options) {
+      if (this.baseUrl) {
+        let urlObj = import_url3.default.parse(uri);
+        uri = import_url3.default.resolve(this.baseUrl, urlObj.path);
       }
-      relative.host = null;
+      return this.xhr.send(req, uri, options);
     }
-    mustEndAbs = mustEndAbs && (relPath[0] === '' || srcPath[0] === '');
-  }
-
-  if (isRelAbs) {
-    // it's absolute.
-    result.host = (relative.host || relative.host === '') ?
-                  relative.host : result.host;
-    result.hostname = (relative.hostname || relative.hostname === '') ?
-                      relative.hostname : result.hostname;
-    result.search = relative.search;
-    result.query = relative.query;
-    srcPath = relPath;
-    // fall through to the dot-handling below.
-  } else if (relPath.length) {
-    // it's relative
-    // throw away the existing file, and take the new path instead.
-    if (!srcPath) srcPath = [];
-    srcPath.pop();
-    srcPath = srcPath.concat(relPath);
-    result.search = relative.search;
-    result.query = relative.query;
-  } else if (!isNullOrUndefined(relative.search)) {
-    // just pull out the search.
-    // like href='?foo'.
-    // Put this after the other two cases because it simplifies the booleans
-    if (psychotic) {
-      result.hostname = result.host = srcPath.shift();
-      //occationaly the auth can get stuck only in host
-      //this especialy happens in cases like
-      //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-      var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                       result.host.split('@') : false;
-      if (authInHost) {
-        result.auth = authInHost.shift();
-        result.host = result.hostname = authInHost.shift();
-      }
+    createAccount(options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return accounts.createAccount(options);
     }
-    result.search = relative.search;
-    result.query = relative.query;
-    //to support http.request
-    if (!isNull(result.pathname) || !isNull(result.search)) {
-      result.path = (result.pathname ? result.pathname : '') +
-                    (result.search ? result.search : '');
+    createCalendarObject(calendar, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return createCalendarObject(calendar, options);
     }
-    result.href = result.format();
-    return result;
-  }
-
-  if (!srcPath.length) {
-    // no path at all.  easy.
-    // we've already handled the other stuff above.
-    result.pathname = null;
-    //to support http.request
-    if (result.search) {
-      result.path = '/' + result.search;
-    } else {
-      result.path = null;
+    updateCalendarObject(calendarObject, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return updateCalendarObject(calendarObject, options);
     }
-    result.href = result.format();
-    return result;
-  }
-
-  // if a url ENDs in . or .., then it must get a trailing slash.
-  // however, if it ends in anything else non-slashy,
-  // then it must NOT get a trailing slash.
-  var last = srcPath.slice(-1)[0];
-  var hasTrailingSlash = (
-      (result.host || relative.host) && (last === '.' || last === '..') ||
-      last === '');
-
-  // strip single dots, resolve double dots to parent dir
-  // if the path tries to go above the root, `up` ends up > 0
-  var up = 0;
-  for (var i = srcPath.length; i >= 0; i--) {
-    last = srcPath[i];
-    if (last == '.') {
-      srcPath.splice(i, 1);
-    } else if (last === '..') {
-      srcPath.splice(i, 1);
-      up++;
-    } else if (up) {
-      srcPath.splice(i, 1);
-      up--;
+    deleteCalendarObject(calendarObject, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return deleteCalendarObject(calendarObject, options);
     }
-  }
-
-  // if the path is allowed to go above the root, restore leading ..s
-  if (!mustEndAbs && !removeAllDots) {
-    for (; up--; up) {
-      srcPath.unshift('..');
+    syncCalendar(calendar, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return syncCalendar(calendar, options);
     }
-  }
-
-  if (mustEndAbs && srcPath[0] !== '' &&
-      (!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
-    srcPath.unshift('');
-  }
-
-  if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
-    srcPath.push('');
-  }
-
-  var isAbsolute = srcPath[0] === '' ||
-      (srcPath[0] && srcPath[0].charAt(0) === '/');
-
-  // put the host back
-  if (psychotic) {
-    result.hostname = result.host = isAbsolute ? '' :
-                                    srcPath.length ? srcPath.shift() : '';
-    //occationaly the auth can get stuck only in host
-    //this especialy happens in cases like
-    //url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-    var authInHost = result.host && result.host.indexOf('@') > 0 ?
-                     result.host.split('@') : false;
-    if (authInHost) {
-      result.auth = authInHost.shift();
-      result.host = result.hostname = authInHost.shift();
+    syncCaldavAccount(account, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return syncCaldavAccount(account, options);
     }
-  }
-
-  mustEndAbs = mustEndAbs || (result.host && srcPath.length);
-
-  if (mustEndAbs && !isAbsolute) {
-    srcPath.unshift('');
-  }
-
-  if (!srcPath.length) {
-    result.pathname = null;
-    result.path = null;
-  } else {
-    result.pathname = srcPath.join('/');
-  }
-
-  //to support request.http
-  if (!isNull(result.pathname) || !isNull(result.search)) {
-    result.path = (result.pathname ? result.pathname : '') +
-                  (result.search ? result.search : '');
-  }
-  result.auth = relative.auth || result.auth;
-  result.slashes = result.slashes || relative.slashes;
-  result.href = result.format();
-  return result;
-};
-
-Url.prototype.parseHost = function() {
-  var host = this.host;
-  var port = portPattern.exec(host);
-  if (port) {
-    port = port[0];
-    if (port !== ':') {
-      this.port = port.substr(1);
+    getAddressBook(options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return getAddressBook(options);
     }
-    host = host.substr(0, host.length - port.length);
+    createAddressBook(options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return createAddressBook(options);
+    }
+    deleteAddressBook(addressBook, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return deleteAddressBook(addressBook, options);
+    }
+    renameAddressBook(addressBook, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return renameAddressBook(addressBook, options);
+    }
+    createCard(addressBook, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return createCard(addressBook, options);
+    }
+    updateCard(card, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return updateCard(card, options);
+    }
+    deleteCard(card, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return deleteCard(card, options);
+    }
+    syncAddressBook(addressBook, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return syncAddressBook(addressBook, options);
+    }
+    syncCarddavAccount(account, options = {}) {
+      options.xhr = options.xhr || this.xhr;
+      return syncCarddavAccount(account, options);
+    }
+  };
+
+  // lib/index.js
+  init_contacts();
+  init_model();
+  init_request();
+
+  // lib/sandbox.js
+  var debug6 = require_debug()("dav:sandbox");
+  var Sandbox = class {
+    constructor() {
+      this.requestList = [];
+    }
+    add(request) {
+      debug6("Adding request to sandbox.");
+      this.requestList.push(request);
+    }
+    abort() {
+      debug6("Aborting sandboxed requests.");
+      this.requestList.forEach((request) => request.abort());
+    }
+  };
+  function createSandbox() {
+    return new Sandbox();
   }
-  if (host) this.hostname = host;
-};
-
-function isString(arg) {
-  return typeof arg === "string";
-}
-
-function isObject(arg) {
-  return typeof arg === 'object' && arg !== null;
-}
-
-function isNull(arg) {
-  return arg === null;
-}
-function isNullOrUndefined(arg) {
-  return  arg == null;
-}
-
-},{"punycode":27,"querystring":30}],32:[function(require,module,exports){
-function DOMParser(options){
-	this.options = options ||{locator:{}};
-	
-}
-DOMParser.prototype.parseFromString = function(source,mimeType){
-	var options = this.options;
-	var sax =  new XMLReader();
-	var domBuilder = options.domBuilder || new DOMHandler();//contentHandler and LexicalHandler
-	var errorHandler = options.errorHandler;
-	var locator = options.locator;
-	var defaultNSMap = options.xmlns||{};
-	var entityMap = {'lt':'<','gt':'>','amp':'&','quot':'"','apos':"'"}
-	if(locator){
-		domBuilder.setDocumentLocator(locator)
-	}
-	
-	sax.errorHandler = buildErrorHandler(errorHandler,domBuilder,locator);
-	sax.domBuilder = options.domBuilder || domBuilder;
-	if(/\/x?html?$/.test(mimeType)){
-		entityMap.nbsp = '\xa0';
-		entityMap.copy = '\xa9';
-		defaultNSMap['']= 'http://www.w3.org/1999/xhtml';
-	}
-	defaultNSMap.xml = defaultNSMap.xml || 'http://www.w3.org/XML/1998/namespace';
-	if(source){
-		sax.parse(source,defaultNSMap,entityMap);
-	}else{
-		sax.errorHandler.error("invalid doc source");
-	}
-	return domBuilder.doc;
-}
-function buildErrorHandler(errorImpl,domBuilder,locator){
-	if(!errorImpl){
-		if(domBuilder instanceof DOMHandler){
-			return domBuilder;
-		}
-		errorImpl = domBuilder ;
-	}
-	var errorHandler = {}
-	var isCallback = errorImpl instanceof Function;
-	locator = locator||{}
-	function build(key){
-		var fn = errorImpl[key];
-		if(!fn && isCallback){
-			fn = errorImpl.length == 2?function(msg){errorImpl(key,msg)}:errorImpl;
-		}
-		errorHandler[key] = fn && function(msg){
-			fn('[xmldom '+key+']\t'+msg+_locator(locator));
-		}||function(){};
-	}
-	build('warning');
-	build('error');
-	build('fatalError');
-	return errorHandler;
-}
-
-//console.log('#\n\n\n\n\n\n\n####')
-/**
- * +ContentHandler+ErrorHandler
- * +LexicalHandler+EntityResolver2
- * -DeclHandler-DTDHandler 
- * 
- * DefaultHandler:EntityResolver, DTDHandler, ContentHandler, ErrorHandler
- * DefaultHandler2:DefaultHandler,LexicalHandler, DeclHandler, EntityResolver2
- * @link http://www.saxproject.org/apidoc/org/xml/sax/helpers/DefaultHandler.html
- */
-function DOMHandler() {
-    this.cdata = false;
-}
-function position(locator,node){
-	node.lineNumber = locator.lineNumber;
-	node.columnNumber = locator.columnNumber;
-}
-/**
- * @see org.xml.sax.ContentHandler#startDocument
- * @link http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
- */ 
-DOMHandler.prototype = {
-	startDocument : function() {
-    	this.doc = new DOMImplementation().createDocument(null, null, null);
-    	if (this.locator) {
-        	this.doc.documentURI = this.locator.systemId;
-    	}
-	},
-	startElement:function(namespaceURI, localName, qName, attrs) {
-		var doc = this.doc;
-	    var el = doc.createElementNS(namespaceURI, qName||localName);
-	    var len = attrs.length;
-	    appendElement(this, el);
-	    this.currentElement = el;
-	    
-		this.locator && position(this.locator,el)
-	    for (var i = 0 ; i < len; i++) {
-	        var namespaceURI = attrs.getURI(i);
-	        var value = attrs.getValue(i);
-	        var qName = attrs.getQName(i);
-			var attr = doc.createAttributeNS(namespaceURI, qName);
-			this.locator &&position(attrs.getLocator(i),attr);
-			attr.value = attr.nodeValue = value;
-			el.setAttributeNode(attr)
-	    }
-	},
-	endElement:function(namespaceURI, localName, qName) {
-		var current = this.currentElement
-		var tagName = current.tagName;
-		this.currentElement = current.parentNode;
-	},
-	startPrefixMapping:function(prefix, uri) {
-	},
-	endPrefixMapping:function(prefix) {
-	},
-	processingInstruction:function(target, data) {
-	    var ins = this.doc.createProcessingInstruction(target, data);
-	    this.locator && position(this.locator,ins)
-	    appendElement(this, ins);
-	},
-	ignorableWhitespace:function(ch, start, length) {
-	},
-	characters:function(chars, start, length) {
-		chars = _toString.apply(this,arguments)
-		//console.log(chars)
-		if(chars){
-			if (this.cdata) {
-				var charNode = this.doc.createCDATASection(chars);
-			} else {
-				var charNode = this.doc.createTextNode(chars);
-			}
-			if(this.currentElement){
-				this.currentElement.appendChild(charNode);
-			}else if(/^\s*$/.test(chars)){
-				this.doc.appendChild(charNode);
-				//process xml
-			}
-			this.locator && position(this.locator,charNode)
-		}
-	},
-	skippedEntity:function(name) {
-	},
-	endDocument:function() {
-		this.doc.normalize();
-	},
-	setDocumentLocator:function (locator) {
-	    if(this.locator = locator){// && !('lineNumber' in locator)){
-	    	locator.lineNumber = 0;
-	    }
-	},
-	//LexicalHandler
-	comment:function(chars, start, length) {
-		chars = _toString.apply(this,arguments)
-	    var comm = this.doc.createComment(chars);
-	    this.locator && position(this.locator,comm)
-	    appendElement(this, comm);
-	},
-	
-	startCDATA:function() {
-	    //used in characters() methods
-	    this.cdata = true;
-	},
-	endCDATA:function() {
-	    this.cdata = false;
-	},
-	
-	startDTD:function(name, publicId, systemId) {
-		var impl = this.doc.implementation;
-	    if (impl && impl.createDocumentType) {
-	        var dt = impl.createDocumentType(name, publicId, systemId);
-	        this.locator && position(this.locator,dt)
-	        appendElement(this, dt);
-	    }
-	},
-	/**
-	 * @see org.xml.sax.ErrorHandler
-	 * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
-	 */
-	warning:function(error) {
-		console.warn('[xmldom warning]\t'+error,_locator(this.locator));
-	},
-	error:function(error) {
-		console.error('[xmldom error]\t'+error,_locator(this.locator));
-	},
-	fatalError:function(error) {
-		console.error('[xmldom fatalError]\t'+error,_locator(this.locator));
-	    throw error;
-	}
-}
-function _locator(l){
-	if(l){
-		return '\n@'+(l.systemId ||'')+'#[line:'+l.lineNumber+',col:'+l.columnNumber+']'
-	}
-}
-function _toString(chars,start,length){
-	if(typeof chars == 'string'){
-		return chars.substr(start,length)
-	}else{//java sax connect width xmldom on rhino(what about: "? && !(chars instanceof String)")
-		if(chars.length >= start+length || start){
-			return new java.lang.String(chars,start,length)+'';
-		}
-		return chars;
-	}
-}
-
-/*
- * @link http://www.saxproject.org/apidoc/org/xml/sax/ext/LexicalHandler.html
- * used method of org.xml.sax.ext.LexicalHandler:
- *  #comment(chars, start, length)
- *  #startCDATA()
- *  #endCDATA()
- *  #startDTD(name, publicId, systemId)
- *
- *
- * IGNORED method of org.xml.sax.ext.LexicalHandler:
- *  #endDTD()
- *  #startEntity(name)
- *  #endEntity(name)
- *
- *
- * @link http://www.saxproject.org/apidoc/org/xml/sax/ext/DeclHandler.html
- * IGNORED method of org.xml.sax.ext.DeclHandler
- * 	#attributeDecl(eName, aName, type, mode, value)
- *  #elementDecl(name, model)
- *  #externalEntityDecl(name, publicId, systemId)
- *  #internalEntityDecl(name, value)
- * @link http://www.saxproject.org/apidoc/org/xml/sax/ext/EntityResolver2.html
- * IGNORED method of org.xml.sax.EntityResolver2
- *  #resolveEntity(String name,String publicId,String baseURI,String systemId)
- *  #resolveEntity(publicId, systemId)
- *  #getExternalSubset(name, baseURI)
- * @link http://www.saxproject.org/apidoc/org/xml/sax/DTDHandler.html
- * IGNORED method of org.xml.sax.DTDHandler
- *  #notationDecl(name, publicId, systemId) {};
- *  #unparsedEntityDecl(name, publicId, systemId, notationName) {};
- */
-"endDTD,startEntity,endEntity,attributeDecl,elementDecl,externalEntityDecl,internalEntityDecl,resolveEntity,getExternalSubset,notationDecl,unparsedEntityDecl".replace(/\w+/g,function(key){
-	DOMHandler.prototype[key] = function(){return null}
-})
-
-/* Private static helpers treated below as private instance methods, so don't need to add these to the public API; we might use a Relator to also get rid of non-standard public properties */
-function appendElement (hander,node) {
-    if (!hander.currentElement) {
-        hander.doc.appendChild(node);
-    } else {
-        hander.currentElement.appendChild(node);
-    }
-}//appendChild and setAttributeNS are preformance key
-
-//if(typeof require == 'function'){
-	var XMLReader = require('./sax').XMLReader;
-	var DOMImplementation = exports.DOMImplementation = require('./dom').DOMImplementation;
-	exports.XMLSerializer = require('./dom').XMLSerializer ;
-	exports.DOMParser = DOMParser;
-//}
-
-},{"./dom":33,"./sax":34}],33:[function(require,module,exports){
-/*
- * DOM Level 2
- * Object DOMException
- * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
- */
-
-function copy(src,dest){
-	for(var p in src){
-		dest[p] = src[p];
-	}
-}
-/**
-^\w+\.prototype\.([_\w]+)\s*=\s*((?:.*\{\s*?[\r\n][\s\S]*?^})|\S.*?(?=[;\r\n]));?
-^\w+\.prototype\.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
- */
-function _extends(Class,Super){
-	var pt = Class.prototype;
-	if(Object.create){
-		var ppt = Object.create(Super.prototype)
-		pt.__proto__ = ppt;
-	}
-	if(!(pt instanceof Super)){
-		function t(){};
-		t.prototype = Super.prototype;
-		t = new t();
-		copy(pt,t);
-		Class.prototype = pt = t;
-	}
-	if(pt.constructor != Class){
-		if(typeof Class != 'function'){
-			console.error("unknow Class:"+Class)
-		}
-		pt.constructor = Class
-	}
-}
-var htmlns = 'http://www.w3.org/1999/xhtml' ;
-// Node Types
-var NodeType = {}
-var ELEMENT_NODE                = NodeType.ELEMENT_NODE                = 1;
-var ATTRIBUTE_NODE              = NodeType.ATTRIBUTE_NODE              = 2;
-var TEXT_NODE                   = NodeType.TEXT_NODE                   = 3;
-var CDATA_SECTION_NODE          = NodeType.CDATA_SECTION_NODE          = 4;
-var ENTITY_REFERENCE_NODE       = NodeType.ENTITY_REFERENCE_NODE       = 5;
-var ENTITY_NODE                 = NodeType.ENTITY_NODE                 = 6;
-var PROCESSING_INSTRUCTION_NODE = NodeType.PROCESSING_INSTRUCTION_NODE = 7;
-var COMMENT_NODE                = NodeType.COMMENT_NODE                = 8;
-var DOCUMENT_NODE               = NodeType.DOCUMENT_NODE               = 9;
-var DOCUMENT_TYPE_NODE          = NodeType.DOCUMENT_TYPE_NODE          = 10;
-var DOCUMENT_FRAGMENT_NODE      = NodeType.DOCUMENT_FRAGMENT_NODE      = 11;
-var NOTATION_NODE               = NodeType.NOTATION_NODE               = 12;
-
-// ExceptionCode
-var ExceptionCode = {}
-var ExceptionMessage = {};
-var INDEX_SIZE_ERR              = ExceptionCode.INDEX_SIZE_ERR              = ((ExceptionMessage[1]="Index size error"),1);
-var DOMSTRING_SIZE_ERR          = ExceptionCode.DOMSTRING_SIZE_ERR          = ((ExceptionMessage[2]="DOMString size error"),2);
-var HIERARCHY_REQUEST_ERR       = ExceptionCode.HIERARCHY_REQUEST_ERR       = ((ExceptionMessage[3]="Hierarchy request error"),3);
-var WRONG_DOCUMENT_ERR          = ExceptionCode.WRONG_DOCUMENT_ERR          = ((ExceptionMessage[4]="Wrong document"),4);
-var INVALID_CHARACTER_ERR       = ExceptionCode.INVALID_CHARACTER_ERR       = ((ExceptionMessage[5]="Invalid character"),5);
-var NO_DATA_ALLOWED_ERR         = ExceptionCode.NO_DATA_ALLOWED_ERR         = ((ExceptionMessage[6]="No data allowed"),6);
-var NO_MODIFICATION_ALLOWED_ERR = ExceptionCode.NO_MODIFICATION_ALLOWED_ERR = ((ExceptionMessage[7]="No modification allowed"),7);
-var NOT_FOUND_ERR               = ExceptionCode.NOT_FOUND_ERR               = ((ExceptionMessage[8]="Not found"),8);
-var NOT_SUPPORTED_ERR           = ExceptionCode.NOT_SUPPORTED_ERR           = ((ExceptionMessage[9]="Not supported"),9);
-var INUSE_ATTRIBUTE_ERR         = ExceptionCode.INUSE_ATTRIBUTE_ERR         = ((ExceptionMessage[10]="Attribute in use"),10);
-//level2
-var INVALID_STATE_ERR        	= ExceptionCode.INVALID_STATE_ERR        	= ((ExceptionMessage[11]="Invalid state"),11);
-var SYNTAX_ERR               	= ExceptionCode.SYNTAX_ERR               	= ((ExceptionMessage[12]="Syntax error"),12);
-var INVALID_MODIFICATION_ERR 	= ExceptionCode.INVALID_MODIFICATION_ERR 	= ((ExceptionMessage[13]="Invalid modification"),13);
-var NAMESPACE_ERR            	= ExceptionCode.NAMESPACE_ERR           	= ((ExceptionMessage[14]="Invalid namespace"),14);
-var INVALID_ACCESS_ERR       	= ExceptionCode.INVALID_ACCESS_ERR      	= ((ExceptionMessage[15]="Invalid access"),15);
-
-
-function DOMException(code, message) {
-	if(message instanceof Error){
-		var error = message;
-	}else{
-		error = this;
-		Error.call(this, ExceptionMessage[code]);
-		this.message = ExceptionMessage[code];
-		if(Error.captureStackTrace) Error.captureStackTrace(this, DOMException);
-	}
-	error.code = code;
-	if(message) this.message = this.message + ": " + message;
-	return error;
-};
-DOMException.prototype = Error.prototype;
-copy(ExceptionCode,DOMException)
-/**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
- * The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
- * The items in the NodeList are accessible via an integral index, starting from 0.
- */
-function NodeList() {
-};
-NodeList.prototype = {
-	/**
-	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
-	 * @standard level1
-	 */
-	length:0, 
-	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
-	 * @standard level1
-	 * @param index  unsigned long 
-	 *   Index into the collection.
-	 * @return Node
-	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index. 
-	 */
-	item: function(index) {
-		return this[index] || null;
-	},
-	toString:function(isHTML,nodeFilter){
-		for(var buf = [], i = 0;i<this.length;i++){
-			serializeToString(this[i],buf,isHTML,nodeFilter);
-		}
-		return buf.join('');
-	}
-};
-function LiveNodeList(node,refresh){
-	this._node = node;
-	this._refresh = refresh
-	_updateLiveList(this);
-}
-function _updateLiveList(list){
-	var inc = list._node._inc || list._node.ownerDocument._inc;
-	if(list._inc != inc){
-		var ls = list._refresh(list._node);
-		//console.log(ls.length)
-		__set__(list,'length',ls.length);
-		copy(ls,list);
-		list._inc = inc;
-	}
-}
-LiveNodeList.prototype.item = function(i){
-	_updateLiveList(this);
-	return this[i];
-}
-
-_extends(LiveNodeList,NodeList);
-/**
- * 
- * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name. Note that NamedNodeMap does not inherit from NodeList; NamedNodeMaps are not maintained in any particular order. Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index, but this is simply to allow convenient enumeration of the contents of a NamedNodeMap, and does not imply that the DOM specifies an order to these Nodes.
- * NamedNodeMap objects in the DOM are live.
- * used for attributes or DocumentType entities 
- */
-function NamedNodeMap() {
-};
-
-function _findNodeIndex(list,node){
-	var i = list.length;
-	while(i--){
-		if(list[i] === node){return i}
-	}
-}
-
-function _addNamedNode(el,list,newAttr,oldAttr){
-	if(oldAttr){
-		list[_findNodeIndex(list,oldAttr)] = newAttr;
-	}else{
-		list[list.length++] = newAttr;
-	}
-	if(el){
-		newAttr.ownerElement = el;
-		var doc = el.ownerDocument;
-		if(doc){
-			oldAttr && _onRemoveAttribute(doc,el,oldAttr);
-			_onAddAttribute(doc,el,newAttr);
-		}
-	}
-}
-function _removeNamedNode(el,list,attr){
-	//console.log('remove attr:'+attr)
-	var i = _findNodeIndex(list,attr);
-	if(i>=0){
-		var lastIndex = list.length-1
-		while(i<lastIndex){
-			list[i] = list[++i]
-		}
-		list.length = lastIndex;
-		if(el){
-			var doc = el.ownerDocument;
-			if(doc){
-				_onRemoveAttribute(doc,el,attr);
-				attr.ownerElement = null;
-			}
-		}
-	}else{
-		throw DOMException(NOT_FOUND_ERR,new Error(el.tagName+'@'+attr))
-	}
-}
-NamedNodeMap.prototype = {
-	length:0,
-	item:NodeList.prototype.item,
-	getNamedItem: function(key) {
-//		if(key.indexOf(':')>0 || key == 'xmlns'){
-//			return null;
-//		}
-		//console.log()
-		var i = this.length;
-		while(i--){
-			var attr = this[i];
-			//console.log(attr.nodeName,key)
-			if(attr.nodeName == key){
-				return attr;
-			}
-		}
-	},
-	setNamedItem: function(attr) {
-		var el = attr.ownerElement;
-		if(el && el!=this._ownerElement){
-			throw new DOMException(INUSE_ATTRIBUTE_ERR);
-		}
-		var oldAttr = this.getNamedItem(attr.nodeName);
-		_addNamedNode(this._ownerElement,this,attr,oldAttr);
-		return oldAttr;
-	},
-	/* returns Node */
-	setNamedItemNS: function(attr) {// raises: WRONG_DOCUMENT_ERR,NO_MODIFICATION_ALLOWED_ERR,INUSE_ATTRIBUTE_ERR
-		var el = attr.ownerElement, oldAttr;
-		if(el && el!=this._ownerElement){
-			throw new DOMException(INUSE_ATTRIBUTE_ERR);
-		}
-		oldAttr = this.getNamedItemNS(attr.namespaceURI,attr.localName);
-		_addNamedNode(this._ownerElement,this,attr,oldAttr);
-		return oldAttr;
-	},
-
-	/* returns Node */
-	removeNamedItem: function(key) {
-		var attr = this.getNamedItem(key);
-		_removeNamedNode(this._ownerElement,this,attr);
-		return attr;
-		
-		
-	},// raises: NOT_FOUND_ERR,NO_MODIFICATION_ALLOWED_ERR
-	
-	//for level2
-	removeNamedItemNS:function(namespaceURI,localName){
-		var attr = this.getNamedItemNS(namespaceURI,localName);
-		_removeNamedNode(this._ownerElement,this,attr);
-		return attr;
-	},
-	getNamedItemNS: function(namespaceURI, localName) {
-		var i = this.length;
-		while(i--){
-			var node = this[i];
-			if(node.localName == localName && node.namespaceURI == namespaceURI){
-				return node;
-			}
-		}
-		return null;
-	}
-};
-/**
- * @see http://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490
- */
-function DOMImplementation(/* Object */ features) {
-	this._features = {};
-	if (features) {
-		for (var feature in features) {
-			 this._features = features[feature];
-		}
-	}
-};
-
-DOMImplementation.prototype = {
-	hasFeature: function(/* string */ feature, /* string */ version) {
-		var versions = this._features[feature.toLowerCase()];
-		if (versions && (!version || version in versions)) {
-			return true;
-		} else {
-			return false;
-		}
-	},
-	// Introduced in DOM Level 2:
-	createDocument:function(namespaceURI,  qualifiedName, doctype){// raises:INVALID_CHARACTER_ERR,NAMESPACE_ERR,WRONG_DOCUMENT_ERR
-		var doc = new Document();
-		doc.implementation = this;
-		doc.childNodes = new NodeList();
-		doc.doctype = doctype;
-		if(doctype){
-			doc.appendChild(doctype);
-		}
-		if(qualifiedName){
-			var root = doc.createElementNS(namespaceURI,qualifiedName);
-			doc.appendChild(root);
-		}
-		return doc;
-	},
-	// Introduced in DOM Level 2:
-	createDocumentType:function(qualifiedName, publicId, systemId){// raises:INVALID_CHARACTER_ERR,NAMESPACE_ERR
-		var node = new DocumentType();
-		node.name = qualifiedName;
-		node.nodeName = qualifiedName;
-		node.publicId = publicId;
-		node.systemId = systemId;
-		// Introduced in DOM Level 2:
-		//readonly attribute DOMString        internalSubset;
-		
-		//TODO:..
-		//  readonly attribute NamedNodeMap     entities;
-		//  readonly attribute NamedNodeMap     notations;
-		return node;
-	}
-};
-
-
-/**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
- */
-
-function Node() {
-};
-
-Node.prototype = {
-	firstChild : null,
-	lastChild : null,
-	previousSibling : null,
-	nextSibling : null,
-	attributes : null,
-	parentNode : null,
-	childNodes : null,
-	ownerDocument : null,
-	nodeValue : null,
-	namespaceURI : null,
-	prefix : null,
-	localName : null,
-	// Modified in DOM Level 2:
-	insertBefore:function(newChild, refChild){//raises 
-		return _insertBefore(this,newChild,refChild);
-	},
-	replaceChild:function(newChild, oldChild){//raises 
-		this.insertBefore(newChild,oldChild);
-		if(oldChild){
-			this.removeChild(oldChild);
-		}
-	},
-	removeChild:function(oldChild){
-		return _removeChild(this,oldChild);
-	},
-	appendChild:function(newChild){
-		return this.insertBefore(newChild,null);
-	},
-	hasChildNodes:function(){
-		return this.firstChild != null;
-	},
-	cloneNode:function(deep){
-		return cloneNode(this.ownerDocument||this,this,deep);
-	},
-	// Modified in DOM Level 2:
-	normalize:function(){
-		var child = this.firstChild;
-		while(child){
-			var next = child.nextSibling;
-			if(next && next.nodeType == TEXT_NODE && child.nodeType == TEXT_NODE){
-				this.removeChild(next);
-				child.appendData(next.data);
-			}else{
-				child.normalize();
-				child = next;
-			}
-		}
-	},
-  	// Introduced in DOM Level 2:
-	isSupported:function(feature, version){
-		return this.ownerDocument.implementation.hasFeature(feature,version);
-	},
-    // Introduced in DOM Level 2:
-    hasAttributes:function(){
-    	return this.attributes.length>0;
-    },
-    lookupPrefix:function(namespaceURI){
-    	var el = this;
-    	while(el){
-    		var map = el._nsMap;
-    		//console.dir(map)
-    		if(map){
-    			for(var n in map){
-    				if(map[n] == namespaceURI){
-    					return n;
-    				}
-    			}
-    		}
-    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerDocument : el.parentNode;
-    	}
-    	return null;
-    },
-    // Introduced in DOM Level 3:
-    lookupNamespaceURI:function(prefix){
-    	var el = this;
-    	while(el){
-    		var map = el._nsMap;
-    		//console.dir(map)
-    		if(map){
-    			if(prefix in map){
-    				return map[prefix] ;
-    			}
-    		}
-    		el = el.nodeType == ATTRIBUTE_NODE?el.ownerDocument : el.parentNode;
-    	}
-    	return null;
-    },
-    // Introduced in DOM Level 3:
-    isDefaultNamespace:function(namespaceURI){
-    	var prefix = this.lookupPrefix(namespaceURI);
-    	return prefix == null;
-    }
-};
-
-
-function _xmlEncoder(c){
-	return c == '<' && '&lt;' ||
-         c == '>' && '&gt;' ||
-         c == '&' && '&amp;' ||
-         c == '"' && '&quot;' ||
-         '&#'+c.charCodeAt()+';'
-}
-
-
-copy(NodeType,Node);
-copy(NodeType,Node.prototype);
-
-/**
- * @param callback return true for continue,false for break
- * @return boolean true: break visit;
- */
-function _visitNode(node,callback){
-	if(callback(node)){
-		return true;
-	}
-	if(node = node.firstChild){
-		do{
-			if(_visitNode(node,callback)){return true}
-        }while(node=node.nextSibling)
-    }
-}
-
-
-
-function Document(){
-}
-function _onAddAttribute(doc,el,newAttr){
-	doc && doc._inc++;
-	var ns = newAttr.namespaceURI ;
-	if(ns == 'http://www.w3.org/2000/xmlns/'){
-		//update namespace
-		el._nsMap[newAttr.prefix?newAttr.localName:''] = newAttr.value
-	}
-}
-function _onRemoveAttribute(doc,el,newAttr,remove){
-	doc && doc._inc++;
-	var ns = newAttr.namespaceURI ;
-	if(ns == 'http://www.w3.org/2000/xmlns/'){
-		//update namespace
-		delete el._nsMap[newAttr.prefix?newAttr.localName:'']
-	}
-}
-function _onUpdateChild(doc,el,newChild){
-	if(doc && doc._inc){
-		doc._inc++;
-		//update childNodes
-		var cs = el.childNodes;
-		if(newChild){
-			cs[cs.length++] = newChild;
-		}else{
-			//console.log(1)
-			var child = el.firstChild;
-			var i = 0;
-			while(child){
-				cs[i++] = child;
-				child =child.nextSibling;
-			}
-			cs.length = i;
-		}
-	}
-}
-
-/**
- * attributes;
- * children;
- * 
- * writeable properties:
- * nodeValue,Attr:value,CharacterData:data
- * prefix
- */
-function _removeChild(parentNode,child){
-	var previous = child.previousSibling;
-	var next = child.nextSibling;
-	if(previous){
-		previous.nextSibling = next;
-	}else{
-		parentNode.firstChild = next
-	}
-	if(next){
-		next.previousSibling = previous;
-	}else{
-		parentNode.lastChild = previous;
-	}
-	_onUpdateChild(parentNode.ownerDocument,parentNode);
-	return child;
-}
-/**
- * preformance key(refChild == null)
- */
-function _insertBefore(parentNode,newChild,nextChild){
-	var cp = newChild.parentNode;
-	if(cp){
-		cp.removeChild(newChild);//remove and update
-	}
-	if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
-		var newFirst = newChild.firstChild;
-		if (newFirst == null) {
-			return newChild;
-		}
-		var newLast = newChild.lastChild;
-	}else{
-		newFirst = newLast = newChild;
-	}
-	var pre = nextChild ? nextChild.previousSibling : parentNode.lastChild;
-
-	newFirst.previousSibling = pre;
-	newLast.nextSibling = nextChild;
-	
-	
-	if(pre){
-		pre.nextSibling = newFirst;
-	}else{
-		parentNode.firstChild = newFirst;
-	}
-	if(nextChild == null){
-		parentNode.lastChild = newLast;
-	}else{
-		nextChild.previousSibling = newLast;
-	}
-	do{
-		newFirst.parentNode = parentNode;
-	}while(newFirst !== newLast && (newFirst= newFirst.nextSibling))
-	_onUpdateChild(parentNode.ownerDocument||parentNode,parentNode);
-	//console.log(parentNode.lastChild.nextSibling == null)
-	if (newChild.nodeType == DOCUMENT_FRAGMENT_NODE) {
-		newChild.firstChild = newChild.lastChild = null;
-	}
-	return newChild;
-}
-function _appendSingleChild(parentNode,newChild){
-	var cp = newChild.parentNode;
-	if(cp){
-		var pre = parentNode.lastChild;
-		cp.removeChild(newChild);//remove and update
-		var pre = parentNode.lastChild;
-	}
-	var pre = parentNode.lastChild;
-	newChild.parentNode = parentNode;
-	newChild.previousSibling = pre;
-	newChild.nextSibling = null;
-	if(pre){
-		pre.nextSibling = newChild;
-	}else{
-		parentNode.firstChild = newChild;
-	}
-	parentNode.lastChild = newChild;
-	_onUpdateChild(parentNode.ownerDocument,parentNode,newChild);
-	return newChild;
-	//console.log("__aa",parentNode.lastChild.nextSibling == null)
-}
-Document.prototype = {
-	//implementation : null,
-	nodeName :  '#document',
-	nodeType :  DOCUMENT_NODE,
-	doctype :  null,
-	documentElement :  null,
-	_inc : 1,
-	
-	insertBefore :  function(newChild, refChild){//raises 
-		if(newChild.nodeType == DOCUMENT_FRAGMENT_NODE){
-			var child = newChild.firstChild;
-			while(child){
-				var next = child.nextSibling;
-				this.insertBefore(child,refChild);
-				child = next;
-			}
-			return newChild;
-		}
-		if(this.documentElement == null && newChild.nodeType == ELEMENT_NODE){
-			this.documentElement = newChild;
-		}
-		
-		return _insertBefore(this,newChild,refChild),(newChild.ownerDocument = this),newChild;
-	},
-	removeChild :  function(oldChild){
-		if(this.documentElement == oldChild){
-			this.documentElement = null;
-		}
-		return _removeChild(this,oldChild);
-	},
-	// Introduced in DOM Level 2:
-	importNode : function(importedNode,deep){
-		return importNode(this,importedNode,deep);
-	},
-	// Introduced in DOM Level 2:
-	getElementById :	function(id){
-		var rtv = null;
-		_visitNode(this.documentElement,function(node){
-			if(node.nodeType == ELEMENT_NODE){
-				if(node.getAttribute('id') == id){
-					rtv = node;
-					return true;
-				}
-			}
-		})
-		return rtv;
-	},
-	
-	//document factory method:
-	createElement :	function(tagName){
-		var node = new Element();
-		node.ownerDocument = this;
-		node.nodeName = tagName;
-		node.tagName = tagName;
-		node.childNodes = new NodeList();
-		var attrs	= node.attributes = new NamedNodeMap();
-		attrs._ownerElement = node;
-		return node;
-	},
-	createDocumentFragment :	function(){
-		var node = new DocumentFragment();
-		node.ownerDocument = this;
-		node.childNodes = new NodeList();
-		return node;
-	},
-	createTextNode :	function(data){
-		var node = new Text();
-		node.ownerDocument = this;
-		node.appendData(data)
-		return node;
-	},
-	createComment :	function(data){
-		var node = new Comment();
-		node.ownerDocument = this;
-		node.appendData(data)
-		return node;
-	},
-	createCDATASection :	function(data){
-		var node = new CDATASection();
-		node.ownerDocument = this;
-		node.appendData(data)
-		return node;
-	},
-	createProcessingInstruction :	function(target,data){
-		var node = new ProcessingInstruction();
-		node.ownerDocument = this;
-		node.tagName = node.target = target;
-		node.nodeValue= node.data = data;
-		return node;
-	},
-	createAttribute :	function(name){
-		var node = new Attr();
-		node.ownerDocument	= this;
-		node.name = name;
-		node.nodeName	= name;
-		node.localName = name;
-		node.specified = true;
-		return node;
-	},
-	createEntityReference :	function(name){
-		var node = new EntityReference();
-		node.ownerDocument	= this;
-		node.nodeName	= name;
-		return node;
-	},
-	// Introduced in DOM Level 2:
-	createElementNS :	function(namespaceURI,qualifiedName){
-		var node = new Element();
-		var pl = qualifiedName.split(':');
-		var attrs	= node.attributes = new NamedNodeMap();
-		node.childNodes = new NodeList();
-		node.ownerDocument = this;
-		node.nodeName = qualifiedName;
-		node.tagName = qualifiedName;
-		node.namespaceURI = namespaceURI;
-		if(pl.length == 2){
-			node.prefix = pl[0];
-			node.localName = pl[1];
-		}else{
-			//el.prefix = null;
-			node.localName = qualifiedName;
-		}
-		attrs._ownerElement = node;
-		return node;
-	},
-	// Introduced in DOM Level 2:
-	createAttributeNS :	function(namespaceURI,qualifiedName){
-		var node = new Attr();
-		var pl = qualifiedName.split(':');
-		node.ownerDocument = this;
-		node.nodeName = qualifiedName;
-		node.name = qualifiedName;
-		node.namespaceURI = namespaceURI;
-		node.specified = true;
-		if(pl.length == 2){
-			node.prefix = pl[0];
-			node.localName = pl[1];
-		}else{
-			//el.prefix = null;
-			node.localName = qualifiedName;
-		}
-		return node;
-	}
-};
-_extends(Document,Node);
-
-
-function Element() {
-	this._nsMap = {};
-};
-Element.prototype = {
-	nodeType : ELEMENT_NODE,
-	hasAttribute : function(name){
-		return this.getAttributeNode(name)!=null;
-	},
-	getAttribute : function(name){
-		var attr = this.getAttributeNode(name);
-		return attr && attr.value || '';
-	},
-	getAttributeNode : function(name){
-		return this.attributes.getNamedItem(name);
-	},
-	setAttribute : function(name, value){
-		var attr = this.ownerDocument.createAttribute(name);
-		attr.value = attr.nodeValue = "" + value;
-		this.setAttributeNode(attr)
-	},
-	removeAttribute : function(name){
-		var attr = this.getAttributeNode(name)
-		attr && this.removeAttributeNode(attr);
-	},
-	
-	//four real opeartion method
-	appendChild:function(newChild){
-		if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
-			return this.insertBefore(newChild,null);
-		}else{
-			return _appendSingleChild(this,newChild);
-		}
-	},
-	setAttributeNode : function(newAttr){
-		return this.attributes.setNamedItem(newAttr);
-	},
-	setAttributeNodeNS : function(newAttr){
-		return this.attributes.setNamedItemNS(newAttr);
-	},
-	removeAttributeNode : function(oldAttr){
-		//console.log(this == oldAttr.ownerElement)
-		return this.attributes.removeNamedItem(oldAttr.nodeName);
-	},
-	//get real attribute name,and remove it by removeAttributeNode
-	removeAttributeNS : function(namespaceURI, localName){
-		var old = this.getAttributeNodeNS(namespaceURI, localName);
-		old && this.removeAttributeNode(old);
-	},
-	
-	hasAttributeNS : function(namespaceURI, localName){
-		return this.getAttributeNodeNS(namespaceURI, localName)!=null;
-	},
-	getAttributeNS : function(namespaceURI, localName){
-		var attr = this.getAttributeNodeNS(namespaceURI, localName);
-		return attr && attr.value || '';
-	},
-	setAttributeNS : function(namespaceURI, qualifiedName, value){
-		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);
-		attr.value = attr.nodeValue = "" + value;
-		this.setAttributeNode(attr)
-	},
-	getAttributeNodeNS : function(namespaceURI, localName){
-		return this.attributes.getNamedItemNS(namespaceURI, localName);
-	},
-	
-	getElementsByTagName : function(tagName){
-		return new LiveNodeList(this,function(base){
-			var ls = [];
-			_visitNode(base,function(node){
-				if(node !== base && node.nodeType == ELEMENT_NODE && (tagName === '*' || node.tagName == tagName)){
-					ls.push(node);
-				}
-			});
-			return ls;
-		});
-	},
-	getElementsByTagNameNS : function(namespaceURI, localName){
-		return new LiveNodeList(this,function(base){
-			var ls = [];
-			_visitNode(base,function(node){
-				if(node !== base && node.nodeType === ELEMENT_NODE && (namespaceURI === '*' || node.namespaceURI === namespaceURI) && (localName === '*' || node.localName == localName)){
-					ls.push(node);
-				}
-			});
-			return ls;
-			
-		});
-	}
-};
-Document.prototype.getElementsByTagName = Element.prototype.getElementsByTagName;
-Document.prototype.getElementsByTagNameNS = Element.prototype.getElementsByTagNameNS;
-
-
-_extends(Element,Node);
-function Attr() {
-};
-Attr.prototype.nodeType = ATTRIBUTE_NODE;
-_extends(Attr,Node);
-
-
-function CharacterData() {
-};
-CharacterData.prototype = {
-	data : '',
-	substringData : function(offset, count) {
-		return this.data.substring(offset, offset+count);
-	},
-	appendData: function(text) {
-		text = this.data+text;
-		this.nodeValue = this.data = text;
-		this.length = text.length;
-	},
-	insertData: function(offset,text) {
-		this.replaceData(offset,0,text);
-	
-	},
-	appendChild:function(newChild){
-		throw new Error(ExceptionMessage[HIERARCHY_REQUEST_ERR])
-	},
-	deleteData: function(offset, count) {
-		this.replaceData(offset,count,"");
-	},
-	replaceData: function(offset, count, text) {
-		var start = this.data.substring(0,offset);
-		var end = this.data.substring(offset+count);
-		text = start + text + end;
-		this.nodeValue = this.data = text;
-		this.length = text.length;
-	}
-}
-_extends(CharacterData,Node);
-function Text() {
-};
-Text.prototype = {
-	nodeName : "#text",
-	nodeType : TEXT_NODE,
-	splitText : function(offset) {
-		var text = this.data;
-		var newText = text.substring(offset);
-		text = text.substring(0, offset);
-		this.data = this.nodeValue = text;
-		this.length = text.length;
-		var newNode = this.ownerDocument.createTextNode(newText);
-		if(this.parentNode){
-			this.parentNode.insertBefore(newNode, this.nextSibling);
-		}
-		return newNode;
-	}
-}
-_extends(Text,CharacterData);
-function Comment() {
-};
-Comment.prototype = {
-	nodeName : "#comment",
-	nodeType : COMMENT_NODE
-}
-_extends(Comment,CharacterData);
-
-function CDATASection() {
-};
-CDATASection.prototype = {
-	nodeName : "#cdata-section",
-	nodeType : CDATA_SECTION_NODE
-}
-_extends(CDATASection,CharacterData);
-
-
-function DocumentType() {
-};
-DocumentType.prototype.nodeType = DOCUMENT_TYPE_NODE;
-_extends(DocumentType,Node);
-
-function Notation() {
-};
-Notation.prototype.nodeType = NOTATION_NODE;
-_extends(Notation,Node);
-
-function Entity() {
-};
-Entity.prototype.nodeType = ENTITY_NODE;
-_extends(Entity,Node);
-
-function EntityReference() {
-};
-EntityReference.prototype.nodeType = ENTITY_REFERENCE_NODE;
-_extends(EntityReference,Node);
-
-function DocumentFragment() {
-};
-DocumentFragment.prototype.nodeName =	"#document-fragment";
-DocumentFragment.prototype.nodeType =	DOCUMENT_FRAGMENT_NODE;
-_extends(DocumentFragment,Node);
-
-
-function ProcessingInstruction() {
-}
-ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
-_extends(ProcessingInstruction,Node);
-function XMLSerializer(){}
-XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter){
-	return nodeSerializeToString.call(node,isHtml,nodeFilter);
-}
-Node.prototype.toString = nodeSerializeToString;
-function nodeSerializeToString(isHtml,nodeFilter){
-	var buf = [];
-	var refNode = this.nodeType == 9?this.documentElement:this;
-	var prefix = refNode.prefix;
-	var uri = refNode.namespaceURI;
-	
-	if(uri && prefix == null){
-		//console.log(prefix)
-		var prefix = refNode.lookupPrefix(uri);
-		if(prefix == null){
-			//isHTML = true;
-			var visibleNamespaces=[
-			{namespace:uri,prefix:null}
-			//{namespace:uri,prefix:''}
-			]
-		}
-	}
-	serializeToString(this,buf,isHtml,nodeFilter,visibleNamespaces);
-	//console.log('###',this.nodeType,uri,prefix,buf.join(''))
-	return buf.join('');
-}
-function needNamespaceDefine(node,isHTML, visibleNamespaces) {
-	var prefix = node.prefix||'';
-	var uri = node.namespaceURI;
-	if (!prefix && !uri){
-		return false;
-	}
-	if (prefix === "xml" && uri === "http://www.w3.org/XML/1998/namespace" 
-		|| uri == 'http://www.w3.org/2000/xmlns/'){
-		return false;
-	}
-	
-	var i = visibleNamespaces.length 
-	//console.log('@@@@',node.tagName,prefix,uri,visibleNamespaces)
-	while (i--) {
-		var ns = visibleNamespaces[i];
-		// get namespace prefix
-		//console.log(node.nodeType,node.tagName,ns.prefix,prefix)
-		if (ns.prefix == prefix){
-			return ns.namespace != uri;
-		}
-	}
-	//console.log(isHTML,uri,prefix=='')
-	//if(isHTML && prefix ==null && uri == 'http://www.w3.org/1999/xhtml'){
-	//	return false;
-	//}
-	//node.flag = '11111'
-	//console.error(3,true,node.flag,node.prefix,node.namespaceURI)
-	return true;
-}
-function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
-	if(nodeFilter){
-		node = nodeFilter(node);
-		if(node){
-			if(typeof node == 'string'){
-				buf.push(node);
-				return;
-			}
-		}else{
-			return;
-		}
-		//buf.sort.apply(attrs, attributeSorter);
-	}
-	switch(node.nodeType){
-	case ELEMENT_NODE:
-		if (!visibleNamespaces) visibleNamespaces = [];
-		var startVisibleNamespaces = visibleNamespaces.length;
-		var attrs = node.attributes;
-		var len = attrs.length;
-		var child = node.firstChild;
-		var nodeName = node.tagName;
-		
-		isHTML =  (htmlns === node.namespaceURI) ||isHTML 
-		buf.push('<',nodeName);
-		
-		
-		
-		for(var i=0;i<len;i++){
-			// add namespaces for attributes
-			var attr = attrs.item(i);
-			if (attr.prefix == 'xmlns') {
-				visibleNamespaces.push({ prefix: attr.localName, namespace: attr.value });
-			}else if(attr.nodeName == 'xmlns'){
-				visibleNamespaces.push({ prefix: '', namespace: attr.value });
-			}
-		}
-		for(var i=0;i<len;i++){
-			var attr = attrs.item(i);
-			if (needNamespaceDefine(attr,isHTML, visibleNamespaces)) {
-				var prefix = attr.prefix||'';
-				var uri = attr.namespaceURI;
-				var ns = prefix ? ' xmlns:' + prefix : " xmlns";
-				buf.push(ns, '="' , uri , '"');
-				visibleNamespaces.push({ prefix: prefix, namespace:uri });
-			}
-			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces);
-		}
-		// add namespace for current node		
-		if (needNamespaceDefine(node,isHTML, visibleNamespaces)) {
-			var prefix = node.prefix||'';
-			var uri = node.namespaceURI;
-			var ns = prefix ? ' xmlns:' + prefix : " xmlns";
-			buf.push(ns, '="' , uri , '"');
-			visibleNamespaces.push({ prefix: prefix, namespace:uri });
-		}
-		
-		if(child || isHTML && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)){
-			buf.push('>');
-			//if is cdata child node
-			if(isHTML && /^script$/i.test(nodeName)){
-				while(child){
-					if(child.data){
-						buf.push(child.data);
-					}else{
-						serializeToString(child,buf,isHTML,nodeFilter,visibleNamespaces);
-					}
-					child = child.nextSibling;
-				}
-			}else
-			{
-				while(child){
-					serializeToString(child,buf,isHTML,nodeFilter,visibleNamespaces);
-					child = child.nextSibling;
-				}
-			}
-			buf.push('</',nodeName,'>');
-		}else{
-			buf.push('/>');
-		}
-		// remove added visible namespaces
-		//visibleNamespaces.length = startVisibleNamespaces;
-		return;
-	case DOCUMENT_NODE:
-	case DOCUMENT_FRAGMENT_NODE:
-		var child = node.firstChild;
-		while(child){
-			serializeToString(child,buf,isHTML,nodeFilter,visibleNamespaces);
-			child = child.nextSibling;
-		}
-		return;
-	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
-	case TEXT_NODE:
-		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
-	case CDATA_SECTION_NODE:
-		return buf.push( '<![CDATA[',node.data,']]>');
-	case COMMENT_NODE:
-		return buf.push( "<!--",node.data,"-->");
-	case DOCUMENT_TYPE_NODE:
-		var pubid = node.publicId;
-		var sysid = node.systemId;
-		buf.push('<!DOCTYPE ',node.name);
-		if(pubid){
-			buf.push(' PUBLIC "',pubid);
-			if (sysid && sysid!='.') {
-				buf.push( '" "',sysid);
-			}
-			buf.push('">');
-		}else if(sysid && sysid!='.'){
-			buf.push(' SYSTEM "',sysid,'">');
-		}else{
-			var sub = node.internalSubset;
-			if(sub){
-				buf.push(" [",sub,"]");
-			}
-			buf.push(">");
-		}
-		return;
-	case PROCESSING_INSTRUCTION_NODE:
-		return buf.push( "<?",node.target," ",node.data,"?>");
-	case ENTITY_REFERENCE_NODE:
-		return buf.push( '&',node.nodeName,';');
-	//case ENTITY_NODE:
-	//case NOTATION_NODE:
-	default:
-		buf.push('??',node.nodeName);
-	}
-}
-function importNode(doc,node,deep){
-	var node2;
-	switch (node.nodeType) {
-	case ELEMENT_NODE:
-		node2 = node.cloneNode(false);
-		node2.ownerDocument = doc;
-		//var attrs = node2.attributes;
-		//var len = attrs.length;
-		//for(var i=0;i<len;i++){
-			//node2.setAttributeNodeNS(importNode(doc,attrs.item(i),deep));
-		//}
-	case DOCUMENT_FRAGMENT_NODE:
-		break;
-	case ATTRIBUTE_NODE:
-		deep = true;
-		break;
-	//case ENTITY_REFERENCE_NODE:
-	//case PROCESSING_INSTRUCTION_NODE:
-	////case TEXT_NODE:
-	//case CDATA_SECTION_NODE:
-	//case COMMENT_NODE:
-	//	deep = false;
-	//	break;
-	//case DOCUMENT_NODE:
-	//case DOCUMENT_TYPE_NODE:
-	//cannot be imported.
-	//case ENTITY_NODE:
-	//case NOTATION_NODE：
-	//can not hit in level3
-	//default:throw e;
-	}
-	if(!node2){
-		node2 = node.cloneNode(false);//false
-	}
-	node2.ownerDocument = doc;
-	node2.parentNode = null;
-	if(deep){
-		var child = node.firstChild;
-		while(child){
-			node2.appendChild(importNode(doc,child,deep));
-			child = child.nextSibling;
-		}
-	}
-	return node2;
-}
-//
-//var _relationMap = {firstChild:1,lastChild:1,previousSibling:1,nextSibling:1,
-//					attributes:1,childNodes:1,parentNode:1,documentElement:1,doctype,};
-function cloneNode(doc,node,deep){
-	var node2 = new node.constructor();
-	for(var n in node){
-		var v = node[n];
-		if(typeof v != 'object' ){
-			if(v != node2[n]){
-				node2[n] = v;
-			}
-		}
-	}
-	if(node.childNodes){
-		node2.childNodes = new NodeList();
-	}
-	node2.ownerDocument = doc;
-	switch (node2.nodeType) {
-	case ELEMENT_NODE:
-		var attrs	= node.attributes;
-		var attrs2	= node2.attributes = new NamedNodeMap();
-		var len = attrs.length
-		attrs2._ownerElement = node2;
-		for(var i=0;i<len;i++){
-			node2.setAttributeNode(cloneNode(doc,attrs.item(i),true));
-		}
-		break;;
-	case ATTRIBUTE_NODE:
-		deep = true;
-	}
-	if(deep){
-		var child = node.firstChild;
-		while(child){
-			node2.appendChild(cloneNode(doc,child,deep));
-			child = child.nextSibling;
-		}
-	}
-	return node2;
-}
-
-function __set__(object,key,value){
-	object[key] = value
-}
-//do dynamic
-try{
-	if(Object.defineProperty){
-		Object.defineProperty(LiveNodeList.prototype,'length',{
-			get:function(){
-				_updateLiveList(this);
-				return this.$$length;
-			}
-		});
-		Object.defineProperty(Node.prototype,'textContent',{
-			get:function(){
-				return getTextContent(this);
-			},
-			set:function(data){
-				switch(this.nodeType){
-				case ELEMENT_NODE:
-				case DOCUMENT_FRAGMENT_NODE:
-					while(this.firstChild){
-						this.removeChild(this.firstChild);
-					}
-					if(data || String(data)){
-						this.appendChild(this.ownerDocument.createTextNode(data));
-					}
-					break;
-				default:
-					//TODO:
-					this.data = data;
-					this.value = data;
-					this.nodeValue = data;
-				}
-			}
-		})
-		
-		function getTextContent(node){
-			switch(node.nodeType){
-			case ELEMENT_NODE:
-			case DOCUMENT_FRAGMENT_NODE:
-				var buf = [];
-				node = node.firstChild;
-				while(node){
-					if(node.nodeType!==7 && node.nodeType !==8){
-						buf.push(getTextContent(node));
-					}
-					node = node.nextSibling;
-				}
-				return buf.join('');
-			default:
-				return node.nodeValue;
-			}
-		}
-		__set__ = function(object,key,value){
-			//console.log(value)
-			object['$$'+key] = value
-		}
-	}
-}catch(e){//ie8
-}
-
-//if(typeof require == 'function'){
-	exports.DOMImplementation = DOMImplementation;
-	exports.XMLSerializer = XMLSerializer;
-//}
-
-},{}],34:[function(require,module,exports){
-//[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-//[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
-//[5]   	Name	   ::=   	NameStartChar (NameChar)*
-var nameStartChar = /[A-Z_a-z\xC0-\xD6\xD8-\xF6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]///\u10000-\uEFFFF
-var nameChar = new RegExp("[\\-\\.0-9"+nameStartChar.source.slice(1,-1)+"\\u00B7\\u0300-\\u036F\\u203F-\\u2040]");
-var tagNamePattern = new RegExp('^'+nameStartChar.source+nameChar.source+'*(?:\:'+nameStartChar.source+nameChar.source+'*)?$');
-//var tagNamePattern = /^[a-zA-Z_][\w\-\.]*(?:\:[a-zA-Z_][\w\-\.]*)?$/
-//var handlers = 'resolveEntity,getExternalSubset,characters,endDocument,endElement,endPrefixMapping,ignorableWhitespace,processingInstruction,setDocumentLocator,skippedEntity,startDocument,startElement,startPrefixMapping,notationDecl,unparsedEntityDecl,error,fatalError,warning,attributeDecl,elementDecl,externalEntityDecl,internalEntityDecl,comment,endCDATA,endDTD,endEntity,startCDATA,startDTD,startEntity'.split(',')
-
-//S_TAG,	S_ATTR,	S_EQ,	S_ATTR_NOQUOT_VALUE
-//S_ATTR_SPACE,	S_ATTR_END,	S_TAG_SPACE, S_TAG_CLOSE
-var S_TAG = 0;//tag name offerring
-var S_ATTR = 1;//attr name offerring 
-var S_ATTR_SPACE=2;//attr name end and space offer
-var S_EQ = 3;//=space?
-var S_ATTR_NOQUOT_VALUE = 4;//attr value(no quot value only)
-var S_ATTR_END = 5;//attr value end and no space(quot end)
-var S_TAG_SPACE = 6;//(attr value end || tag end ) && (space offer)
-var S_TAG_CLOSE = 7;//closed el<el />
-
-function XMLReader(){
-	
-}
-
-XMLReader.prototype = {
-	parse:function(source,defaultNSMap,entityMap){
-		var domBuilder = this.domBuilder;
-		domBuilder.startDocument();
-		_copy(defaultNSMap ,defaultNSMap = {})
-		parse(source,defaultNSMap,entityMap,
-				domBuilder,this.errorHandler);
-		domBuilder.endDocument();
-	}
-}
-function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
-	function fixedFromCharCode(code) {
-		// String.prototype.fromCharCode does not supports
-		// > 2 bytes unicode chars directly
-		if (code > 0xffff) {
-			code -= 0x10000;
-			var surrogate1 = 0xd800 + (code >> 10)
-				, surrogate2 = 0xdc00 + (code & 0x3ff);
-
-			return String.fromCharCode(surrogate1, surrogate2);
-		} else {
-			return String.fromCharCode(code);
-		}
-	}
-	function entityReplacer(a){
-		var k = a.slice(1,-1);
-		if(k in entityMap){
-			return entityMap[k]; 
-		}else if(k.charAt(0) === '#'){
-			return fixedFromCharCode(parseInt(k.substr(1).replace('x','0x')))
-		}else{
-			errorHandler.error('entity not found:'+a);
-			return a;
-		}
-	}
-	function appendText(end){//has some bugs
-		if(end>start){
-			var xt = source.substring(start,end).replace(/&#?\w+;/g,entityReplacer);
-			locator&&position(start);
-			domBuilder.characters(xt,0,end-start);
-			start = end
-		}
-	}
-	function position(p,m){
-		while(p>=lineEnd && (m = linePattern.exec(source))){
-			lineStart = m.index;
-			lineEnd = lineStart + m[0].length;
-			locator.lineNumber++;
-			//console.log('line++:',locator,startPos,endPos)
-		}
-		locator.columnNumber = p-lineStart+1;
-	}
-	var lineStart = 0;
-	var lineEnd = 0;
-	var linePattern = /.*(?:\r\n?|\n)|.*$/g
-	var locator = domBuilder.locator;
-	
-	var parseStack = [{currentNSMap:defaultNSMapCopy}]
-	var closeMap = {};
-	var start = 0;
-	while(true){
-		try{
-			var tagStart = source.indexOf('<',start);
-			if(tagStart<0){
-				if(!source.substr(start).match(/^\s*$/)){
-					var doc = domBuilder.doc;
-	    			var text = doc.createTextNode(source.substr(start));
-	    			doc.appendChild(text);
-	    			domBuilder.currentElement = text;
-				}
-				return;
-			}
-			if(tagStart>start){
-				appendText(tagStart);
-			}
-			switch(source.charAt(tagStart+1)){
-			case '/':
-				var end = source.indexOf('>',tagStart+3);
-				var tagName = source.substring(tagStart+2,end);
-				var config = parseStack.pop();
-				if(end<0){
-					
-	        		tagName = source.substring(tagStart+2).replace(/[\s<].*/,'');
-	        		//console.error('#@@@@@@'+tagName)
-	        		errorHandler.error("end tag name: "+tagName+' is not complete:'+config.tagName);
-	        		end = tagStart+1+tagName.length;
-	        	}else if(tagName.match(/\s</)){
-	        		tagName = tagName.replace(/[\s<].*/,'');
-	        		errorHandler.error("end tag name: "+tagName+' maybe not complete');
-	        		end = tagStart+1+tagName.length;
-				}
-				//console.error(parseStack.length,parseStack)
-				//console.error(config);
-				var localNSMap = config.localNSMap;
-				var endMatch = config.tagName == tagName;
-				var endIgnoreCaseMach = endMatch || config.tagName&&config.tagName.toLowerCase() == tagName.toLowerCase()
-		        if(endIgnoreCaseMach){
-		        	domBuilder.endElement(config.uri,config.localName,tagName);
-					if(localNSMap){
-						for(var prefix in localNSMap){
-							domBuilder.endPrefixMapping(prefix) ;
-						}
-					}
-					if(!endMatch){
-		            	errorHandler.fatalError("end tag name: "+tagName+' is not match the current start tagName:'+config.tagName );
-					}
-		        }else{
-		        	parseStack.push(config)
-		        }
-				
-				end++;
-				break;
-				// end elment
-			case '?':// <?...?>
-				locator&&position(tagStart);
-				end = parseInstruction(source,tagStart,domBuilder);
-				break;
-			case '!':// <!doctype,<![CDATA,<!--
-				locator&&position(tagStart);
-				end = parseDCC(source,tagStart,domBuilder,errorHandler);
-				break;
-			default:
-				locator&&position(tagStart);
-				var el = new ElementAttributes();
-				var currentNSMap = parseStack[parseStack.length-1].currentNSMap;
-				//elStartEnd
-				var end = parseElementStartPart(source,tagStart,el,currentNSMap,entityReplacer,errorHandler);
-				var len = el.length;
-				
-				
-				if(!el.closed && fixSelfClosed(source,end,el.tagName,closeMap)){
-					el.closed = true;
-					if(!entityMap.nbsp){
-						errorHandler.warning('unclosed xml attribute');
-					}
-				}
-				if(locator && len){
-					var locator2 = copyLocator(locator,{});
-					//try{//attribute position fixed
-					for(var i = 0;i<len;i++){
-						var a = el[i];
-						position(a.offset);
-						a.locator = copyLocator(locator,{});
-					}
-					//}catch(e){console.error('@@@@@'+e)}
-					domBuilder.locator = locator2
-					if(appendElement(el,domBuilder,currentNSMap)){
-						parseStack.push(el)
-					}
-					domBuilder.locator = locator;
-				}else{
-					if(appendElement(el,domBuilder,currentNSMap)){
-						parseStack.push(el)
-					}
-				}
-				
-				
-				
-				if(el.uri === 'http://www.w3.org/1999/xhtml' && !el.closed){
-					end = parseHtmlSpecialContent(source,end,el.tagName,entityReplacer,domBuilder)
-				}else{
-					end++;
-				}
-			}
-		}catch(e){
-			errorHandler.error('element parse error: '+e)
-			//errorHandler.error('element parse error: '+e);
-			end = -1;
-			//throw e;
-		}
-		if(end>start){
-			start = end;
-		}else{
-			//TODO: 这里有可能sax回退，有位置错误风险
-			appendText(Math.max(tagStart,start)+1);
-		}
-	}
-}
-function copyLocator(f,t){
-	t.lineNumber = f.lineNumber;
-	t.columnNumber = f.columnNumber;
-	return t;
-}
-
-/**
- * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
- * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
- */
-function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,errorHandler){
-	var attrName;
-	var value;
-	var p = ++start;
-	var s = S_TAG;//status
-	while(true){
-		var c = source.charAt(p);
-		switch(c){
-		case '=':
-			if(s === S_ATTR){//attrName
-				attrName = source.slice(start,p);
-				s = S_EQ;
-			}else if(s === S_ATTR_SPACE){
-				s = S_EQ;
-			}else{
-				//fatalError: equal must after attrName or space after attrName
-				throw new Error('attribute equal must after attrName');
-			}
-			break;
-		case '\'':
-		case '"':
-			if(s === S_EQ || s === S_ATTR //|| s == S_ATTR_SPACE
-				){//equal
-				if(s === S_ATTR){
-					errorHandler.warning('attribute value must after "="')
-					attrName = source.slice(start,p)
-				}
-				start = p+1;
-				p = source.indexOf(c,start)
-				if(p>0){
-					value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
-					el.add(attrName,value,start-1);
-					s = S_ATTR_END;
-				}else{
-					//fatalError: no end quot match
-					throw new Error('attribute value no end \''+c+'\' match');
-				}
-			}else if(s == S_ATTR_NOQUOT_VALUE){
-				value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
-				//console.log(attrName,value,start,p)
-				el.add(attrName,value,start);
-				//console.dir(el)
-				errorHandler.warning('attribute "'+attrName+'" missed start quot('+c+')!!');
-				start = p+1;
-				s = S_ATTR_END
-			}else{
-				//fatalError: no equal before
-				throw new Error('attribute value must after "="');
-			}
-			break;
-		case '/':
-			switch(s){
-			case S_TAG:
-				el.setTagName(source.slice(start,p));
-			case S_ATTR_END:
-			case S_TAG_SPACE:
-			case S_TAG_CLOSE:
-				s =S_TAG_CLOSE;
-				el.closed = true;
-			case S_ATTR_NOQUOT_VALUE:
-			case S_ATTR:
-			case S_ATTR_SPACE:
-				break;
-			//case S_EQ:
-			default:
-				throw new Error("attribute invalid close char('/')")
-			}
-			break;
-		case ''://end document
-			//throw new Error('unexpected end of input')
-			errorHandler.error('unexpected end of input');
-			if(s == S_TAG){
-				el.setTagName(source.slice(start,p));
-			}
-			return p;
-		case '>':
-			switch(s){
-			case S_TAG:
-				el.setTagName(source.slice(start,p));
-			case S_ATTR_END:
-			case S_TAG_SPACE:
-			case S_TAG_CLOSE:
-				break;//normal
-			case S_ATTR_NOQUOT_VALUE://Compatible state
-			case S_ATTR:
-				value = source.slice(start,p);
-				if(value.slice(-1) === '/'){
-					el.closed  = true;
-					value = value.slice(0,-1)
-				}
-			case S_ATTR_SPACE:
-				if(s === S_ATTR_SPACE){
-					value = attrName;
-				}
-				if(s == S_ATTR_NOQUOT_VALUE){
-					errorHandler.warning('attribute "'+value+'" missed quot(")!!');
-					el.add(attrName,value.replace(/&#?\w+;/g,entityReplacer),start)
-				}else{
-					if(currentNSMap[''] !== 'http://www.w3.org/1999/xhtml' || !value.match(/^(?:disabled|checked|selected)$/i)){
-						errorHandler.warning('attribute "'+value+'" missed value!! "'+value+'" instead!!')
-					}
-					el.add(value,value,start)
-				}
-				break;
-			case S_EQ:
-				throw new Error('attribute value missed!!');
-			}
-//			console.log(tagName,tagNamePattern,tagNamePattern.test(tagName))
-			return p;
-		/*xml space '\x20' | #x9 | #xD | #xA; */
-		case '\u0080':
-			c = ' ';
-		default:
-			if(c<= ' '){//space
-				switch(s){
-				case S_TAG:
-					el.setTagName(source.slice(start,p));//tagName
-					s = S_TAG_SPACE;
-					break;
-				case S_ATTR:
-					attrName = source.slice(start,p)
-					s = S_ATTR_SPACE;
-					break;
-				case S_ATTR_NOQUOT_VALUE:
-					var value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
-					errorHandler.warning('attribute "'+value+'" missed quot(")!!');
-					el.add(attrName,value,start)
-				case S_ATTR_END:
-					s = S_TAG_SPACE;
-					break;
-				//case S_TAG_SPACE:
-				//case S_EQ:
-				//case S_ATTR_SPACE:
-				//	void();break;
-				//case S_TAG_CLOSE:
-					//ignore warning
-				}
-			}else{//not space
-//S_TAG,	S_ATTR,	S_EQ,	S_ATTR_NOQUOT_VALUE
-//S_ATTR_SPACE,	S_ATTR_END,	S_TAG_SPACE, S_TAG_CLOSE
-				switch(s){
-				//case S_TAG:void();break;
-				//case S_ATTR:void();break;
-				//case S_ATTR_NOQUOT_VALUE:void();break;
-				case S_ATTR_SPACE:
-					var tagName =  el.tagName;
-					if(currentNSMap[''] !== 'http://www.w3.org/1999/xhtml' || !attrName.match(/^(?:disabled|checked|selected)$/i)){
-						errorHandler.warning('attribute "'+attrName+'" missed value!! "'+attrName+'" instead2!!')
-					}
-					el.add(attrName,attrName,start);
-					start = p;
-					s = S_ATTR;
-					break;
-				case S_ATTR_END:
-					errorHandler.warning('attribute space is required"'+attrName+'"!!')
-				case S_TAG_SPACE:
-					s = S_ATTR;
-					start = p;
-					break;
-				case S_EQ:
-					s = S_ATTR_NOQUOT_VALUE;
-					start = p;
-					break;
-				case S_TAG_CLOSE:
-					throw new Error("elements closed character '/' and '>' must be connected to");
-				}
-			}
-		}//end outer switch
-		//console.log('p++',p)
-		p++;
-	}
-}
-/**
- * @return true if has new namespace define
- */
-function appendElement(el,domBuilder,currentNSMap){
-	var tagName = el.tagName;
-	var localNSMap = null;
-	//var currentNSMap = parseStack[parseStack.length-1].currentNSMap;
-	var i = el.length;
-	while(i--){
-		var a = el[i];
-		var qName = a.qName;
-		var value = a.value;
-		var nsp = qName.indexOf(':');
-		if(nsp>0){
-			var prefix = a.prefix = qName.slice(0,nsp);
-			var localName = qName.slice(nsp+1);
-			var nsPrefix = prefix === 'xmlns' && localName
-		}else{
-			localName = qName;
-			prefix = null
-			nsPrefix = qName === 'xmlns' && ''
-		}
-		//can not set prefix,because prefix !== ''
-		a.localName = localName ;
-		//prefix == null for no ns prefix attribute 
-		if(nsPrefix !== false){//hack!!
-			if(localNSMap == null){
-				localNSMap = {}
-				//console.log(currentNSMap,0)
-				_copy(currentNSMap,currentNSMap={})
-				//console.log(currentNSMap,1)
-			}
-			currentNSMap[nsPrefix] = localNSMap[nsPrefix] = value;
-			a.uri = 'http://www.w3.org/2000/xmlns/'
-			domBuilder.startPrefixMapping(nsPrefix, value) 
-		}
-	}
-	var i = el.length;
-	while(i--){
-		a = el[i];
-		var prefix = a.prefix;
-		if(prefix){//no prefix attribute has no namespace
-			if(prefix === 'xml'){
-				a.uri = 'http://www.w3.org/XML/1998/namespace';
-			}if(prefix !== 'xmlns'){
-				a.uri = currentNSMap[prefix || '']
-				
-				//{console.log('###'+a.qName,domBuilder.locator.systemId+'',currentNSMap,a.uri)}
-			}
-		}
-	}
-	var nsp = tagName.indexOf(':');
-	if(nsp>0){
-		prefix = el.prefix = tagName.slice(0,nsp);
-		localName = el.localName = tagName.slice(nsp+1);
-	}else{
-		prefix = null;//important!!
-		localName = el.localName = tagName;
-	}
-	//no prefix element has default namespace
-	var ns = el.uri = currentNSMap[prefix || ''];
-	domBuilder.startElement(ns,localName,tagName,el);
-	//endPrefixMapping and startPrefixMapping have not any help for dom builder
-	//localNSMap = null
-	if(el.closed){
-		domBuilder.endElement(ns,localName,tagName);
-		if(localNSMap){
-			for(prefix in localNSMap){
-				domBuilder.endPrefixMapping(prefix) 
-			}
-		}
-	}else{
-		el.currentNSMap = currentNSMap;
-		el.localNSMap = localNSMap;
-		//parseStack.push(el);
-		return true;
-	}
-}
-function parseHtmlSpecialContent(source,elStartEnd,tagName,entityReplacer,domBuilder){
-	if(/^(?:script|textarea)$/i.test(tagName)){
-		var elEndStart =  source.indexOf('</'+tagName+'>',elStartEnd);
-		var text = source.substring(elStartEnd+1,elEndStart);
-		if(/[&<]/.test(text)){
-			if(/^script$/i.test(tagName)){
-				//if(!/\]\]>/.test(text)){
-					//lexHandler.startCDATA();
-					domBuilder.characters(text,0,text.length);
-					//lexHandler.endCDATA();
-					return elEndStart;
-				//}
-			}//}else{//text area
-				text = text.replace(/&#?\w+;/g,entityReplacer);
-				domBuilder.characters(text,0,text.length);
-				return elEndStart;
-			//}
-			
-		}
-	}
-	return elStartEnd+1;
-}
-function fixSelfClosed(source,elStartEnd,tagName,closeMap){
-	//if(tagName in closeMap){
-	var pos = closeMap[tagName];
-	if(pos == null){
-		//console.log(tagName)
-		pos =  source.lastIndexOf('</'+tagName+'>')
-		if(pos<elStartEnd){//忘记闭合
-			pos = source.lastIndexOf('</'+tagName)
-		}
-		closeMap[tagName] =pos
-	}
-	return pos<elStartEnd;
-	//} 
-}
-function _copy(source,target){
-	for(var n in source){target[n] = source[n]}
-}
-function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
-	var next= source.charAt(start+2)
-	switch(next){
-	case '-':
-		if(source.charAt(start + 3) === '-'){
-			var end = source.indexOf('-->',start+4);
-			//append comment source.substring(4,end)//<!--
-			if(end>start){
-				domBuilder.comment(source,start+4,end-start-4);
-				return end+3;
-			}else{
-				errorHandler.error("Unclosed comment");
-				return -1;
-			}
-		}else{
-			//error
-			return -1;
-		}
-	default:
-		if(source.substr(start+3,6) == 'CDATA['){
-			var end = source.indexOf(']]>',start+9);
-			domBuilder.startCDATA();
-			domBuilder.characters(source,start+9,end-start-9);
-			domBuilder.endCDATA() 
-			return end+3;
-		}
-		//<!DOCTYPE
-		//startDTD(java.lang.String name, java.lang.String publicId, java.lang.String systemId) 
-		var matchs = split(source,start);
-		var len = matchs.length;
-		if(len>1 && /!doctype/i.test(matchs[0][0])){
-			var name = matchs[1][0];
-			var pubid = len>3 && /^public$/i.test(matchs[2][0]) && matchs[3][0]
-			var sysid = len>4 && matchs[4][0];
-			var lastMatch = matchs[len-1]
-			domBuilder.startDTD(name,pubid && pubid.replace(/^(['"])(.*?)\1$/,'$2'),
-					sysid && sysid.replace(/^(['"])(.*?)\1$/,'$2'));
-			domBuilder.endDTD();
-			
-			return lastMatch.index+lastMatch[0].length
-		}
-	}
-	return -1;
-}
-
-
-
-function parseInstruction(source,start,domBuilder){
-	var end = source.indexOf('?>',start);
-	if(end){
-		var match = source.substring(start,end).match(/^<\?(\S*)\s*([\s\S]*?)\s*$/);
-		if(match){
-			var len = match[0].length;
-			domBuilder.processingInstruction(match[1], match[2]) ;
-			return end+2;
-		}else{//error
-			return -1;
-		}
-	}
-	return -1;
-}
-
-/**
- * @param source
- */
-function ElementAttributes(source){
-	
-}
-ElementAttributes.prototype = {
-	setTagName:function(tagName){
-		if(!tagNamePattern.test(tagName)){
-			throw new Error('invalid tagName:'+tagName)
-		}
-		this.tagName = tagName
-	},
-	add:function(qName,value,offset){
-		if(!tagNamePattern.test(qName)){
-			throw new Error('invalid attribute:'+qName)
-		}
-		this[this.length++] = {qName:qName,value:value,offset:offset}
-	},
-	length:0,
-	getLocalName:function(i){return this[i].localName},
-	getLocator:function(i){return this[i].locator},
-	getQName:function(i){return this[i].qName},
-	getURI:function(i){return this[i].uri},
-	getValue:function(i){return this[i].value}
-//	,getIndex:function(uri, localName)){
-//		if(localName){
-//			
-//		}else{
-//			var qName = uri
-//		}
-//	},
-//	getValue:function(){return this.getValue(this.getIndex.apply(this,arguments))},
-//	getType:function(uri,localName){}
-//	getType:function(i){},
-}
-
-
-
-
-function _set_proto_(thiz,parent){
-	thiz.__proto__ = parent;
-	return thiz;
-}
-if(!(_set_proto_({},_set_proto_.prototype) instanceof _set_proto_)){
-	_set_proto_ = function(thiz,parent){
-		function p(){};
-		p.prototype = parent;
-		p = new p();
-		for(parent in thiz){
-			p[parent] = thiz[parent];
-		}
-		return p;
-	}
-}
-
-function split(source,start){
-	var match;
-	var buf = [];
-	var reg = /'[^']+'|"[^"]+"|[^\s<>\/=]+=?|(\/?\s*>|<)/g;
-	reg.lastIndex = start;
-	reg.exec(source);//skip <
-	while(match = reg.exec(source)){
-		buf.push(match);
-		if(match[1])return buf;
-	}
-}
-
-exports.XMLReader = XMLReader;
-
-
-},{}],35:[function(require,module,exports){
-module.exports={
-  "name": "dav",
-  "version": "1.8.0",
-  "author": "Gareth Aye [:gaye] <gaye@mozilla.com>",
-  "description": "WebDAV, CalDAV, and CardDAV client for nodejs and the browser",
-  "license": "MPL-2.0",
-  "main": "./dav.js",
-  "repository": "https://github.com/gaye/dav",
-  "keywords": [
-    "address book",
-    "calendar",
-    "contacts",
-    "dav",
-    "caldav",
-    "carddav",
-    "webdav",
-    "ical",
-    "vcard",
-    "sync",
-    "rfc 4791",
-    "rfc 6352",
-    "rfc 6578"
-  ],
-  "dependencies": {
-    "co": "^4.6.0",
-    "xmldom": "^0.1.19",
-    "xmlhttprequest": "^1.7.0"
-  },
-  "devDependencies": {
-    "babel": "^5.8.23",
-    "browserify": "^11.0.1",
-    "chai": "^3.2.0",
-    "doctoc": "^0.15.0",
-    "mocha": "^2.3.2",
-    "nock": "^2.10.0",
-    "sinon": "^1.16.1",
-    "tcp-port-used": "^0.1.2",
-    "uglify-js": "^2.4.24"
-  },
-  "scripts": {
-    "test": "make test"
-  }
-}
-
-},{}]},{},[8])(8)
-});
+  return __toCommonJS(index_exports);
+})();
+/*! Bundled license information:
+
+punycode/punycode.js:
+  (*! https://mths.be/punycode v1.3.2 by @mathias *)
+*/

--- a/js/dav/lib/debug.js
+++ b/js/dav/lib/debug.js
@@ -1,7 +1,7 @@
-export default function debug(topic) {
+module.exports = function debug(topic) {
   return function(message) {
     if (debug.enabled) {
       console.log(`[${topic}] ${message}`);
     }
   };
-}
+};

--- a/js/dav/lib/parser.js
+++ b/js/dav/lib/parser.js
@@ -2,7 +2,7 @@ import camelize from './camelize';
 
 let debug = require('./debug')('dav:parser');
 
-let DOMParser = require('xmldom').DOMParser;
+let DOMParser = require('@xmldom/xmldom').DOMParser;
 
 export function multistatus(string) {
   let parser = new DOMParser();

--- a/js/dav/package.json
+++ b/js/dav/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "co": "^4.6.0",
-    "xmldom": "^0.1.19",
+    "@xmldom/xmldom": "^0.8.13",
     "xmlhttprequest": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Migrate the vendored WebDAV/CalDAV/CardDAV client (`js/dav`) from the abandoned
`xmldom` package to its maintained successor `@xmldom/xmldom` (`^0.8.13`).

## Why
`xmldom@0.1.x` carries **1 critical + 5 high** Dependabot advisories on the
runtime dependency, all with **no patch available** on the `xmldom` line
(vulnerable range `<= 0.6.0`, `first_patched_version: none`). The project was
renamed to `@xmldom/xmldom`, where these are fixed. This clears the runtime
security alerts blocking the app for the ownCloud 11 release.

## Changes
- **`js/dav/lib/parser.js`** — `require('@xmldom/xmldom')` instead of `'xmldom'`.
  The only usage is `new DOMParser().parseFromString(str, 'text/xml')`, whose
  API is identical across both packages.
- **`js/dav/package.json`** — swap the dependency (`@xmldom/xmldom ^0.8.13`).
- **`js/dav/lib/debug.js`** — export via `module.exports` (was `export default`)
  so the module resolves under a modern bundler. Behaviour is unchanged
  (`debug(topic)(message)`); all seven `require('./debug')` call sites and the
  one `import debug from './debug'` continue to work.
- **`js/dav/dav.js`** — regenerated browser bundle.

## Note on the bundle rebuild
`dav.js` is a prebuilt browser bundle. The original toolchain
(`browserify@11` / `babel@5`, ~2015) no longer installs on current npm, so the
bundle was rebuilt with **esbuild** (IIFE, global `dav`, browser platform).

Verification performed:
- The exported `dav` API is **identical** to the previous bundle — 36 exports,
  `version 1.8.0` (diffed programmatically).
- `@xmldom/xmldom` round-trips a CalDAV/CardDAV `multistatus` document through
  the `parser.js` code path.
- No `require('xmldom')` remains in the shipped bundle.

The large `dav.js` diff is entirely the regenerated bundle; the reviewable
change is the three source files above.
