### PR TITLE
fix(deps): bump karma from ^4.4 to ^6.4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,15 +2,25 @@ var gulp = require('gulp'),
 	concat = require('gulp-concat'),
 	eslint = require('gulp-eslint'),
 	ngAnnotate = require('gulp-ng-annotate'),
-	KarmaServer = require('karma').Server,
+	karma = require('karma'),
 	sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('karma', function(done){
-	KarmaServer.start({
-		configFile: __dirname + '/karma.conf.js',
-		singleRun: true
-	}, function() {
-		done();
+	karma.config.parseConfig(
+		__dirname + '/karma.conf.js',
+		{ singleRun: true },
+		{ promiseConfig: true, throwErrors: true }
+	).then(function(karmaConfig) {
+		var server = new karma.Server(karmaConfig, function(exitCode) {
+			if (exitCode !== 0) {
+				done(new Error('Karma exited with code ' + exitCode));
+			} else {
+				done();
+			}
+		});
+		server.start();
+	}).catch(function(err) {
+		done(err);
 	});
 });
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-eslint": "^3.0.1",
     "gulp-ng-annotate": "^2.0.0",
     "gulp-sourcemaps": "^1.6.0",
-    "karma": "^4.4",
+    "karma": "^6.4",
     "karma-chai": "^0.1.0",
     "karma-coverage": "^1.1.2",
     "karma-firefox-launcher": "^1.3.0",


### PR DESCRIPTION
## What
Bump the `karma` test runner from `^4.4` to `^6.4`.

## Why
Clears the two remaining open Dependabot advisories on this repo, both in
`karma`:
- **Open redirect** — fixed in `6.3.16`
- **Cross-site scripting** — fixed in `6.3.14`

`karma` is a `devDependency` (test-only) and is never shipped in the app
tarball, so there is no runtime impact for users.

## Compatibility
- The existing `karma.conf.js` loads unchanged under karma 6, verified via
  `karma.config.parseConfig(...)` (frameworks/reporters/browsers resolve, plugin
  autoload intact).
- All `karma-*` plugins install cleanly alongside karma 6.4.4; no config
  migration required.

## Verification
JS-unit CI (`make test-js` → `npm run test` → gulp karma, Firefox) exercises the
full run.
