### PR TITLE
chore(deps): Revert "Bump karma-mocha from 1.3.0 to 2.0.1 (#771)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "bower": "^1.7.9",
-    "chai": "^6.2.2",
+    "chai": "^3.5.0",
     "codecov": "^3.6.5",
     "gulp": "^4.0.0",
     "gulp-cli": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^3.0.1",
     "gulp-ng-annotate": "^2.0.0",
-    "gulp-sourcemaps": "^3.0.0",
+    "gulp-sourcemaps": "^1.6.0",
     "karma": "^6.4",
     "karma-chai": "^0.1.0",
     "karma-coverage": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai": "^6.2.2",
     "codecov": "^3.6.5",
     "gulp": "^4.0.0",
-    "gulp-cli": "^3.1.0",
+    "gulp-cli": "^1.4.0",
     "gulp-concat": "^2.6.0",
     "gulp-eslint": "^3.0.1",
     "gulp-ng-annotate": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "karma-chai": "^0.1.0",
     "karma-coverage": "^1.1.2",
     "karma-firefox-launcher": "^1.3.0",
-    "karma-mocha": "^2.0.1",
+    "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-sinon": "^1.0.5",
     "karma-webdriver-launcher": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "karma-sinon": "^1.0.5",
     "karma-webdriver-launcher": "^1.0.7",
     "mocha": "^5.2",
-    "sinon": "^22.0.0"
+    "sinon": "^1.17.5"
   }
 }


### PR DESCRIPTION
This reverts commit e6503c8b39bf8df508f66a1a0062b9b47527f100.
PR #771 

And revert PR #770 #769 #768 #767

CI is green again. Some combination was the problem. Somehow the PR looks like it passed, and so it was merged.

dependabot can make a new PR for each of these again, and we will get individual results.


